### PR TITLE
Expose connected_device sensor, add clear-bonds/disconnect buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ Grandma still won't answer. But now *the whole house knows.*
 ---
 
 # ESPHome ANCS Component
-
+[![ESPHome](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwonderslug%2Fesphome-ancs%2Fmaster%2Frequirements.txt&search=esphome%3D%3D%28.%2A%29&replace=%241&label=ESPHome&logo=esphome&logoColor=white&color=000000)](requirements.txt)
 [![ESPHome Compile](https://github.com/wonderslug/esphome-ancs/actions/workflows/compile.yml/badge.svg)](https://github.com/wonderslug/esphome-ancs/actions/workflows/compile.yml)
 [![Host Unit Tests](https://github.com/wonderslug/esphome-ancs/actions/workflows/test.yml/badge.svg)](https://github.com/wonderslug/esphome-ancs/actions/workflows/test.yml)
 [![Lint](https://github.com/wonderslug/esphome-ancs/actions/workflows/lint.yml/badge.svg)](https://github.com/wonderslug/esphome-ancs/actions/workflows/lint.yml)
-[![ESPHome](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwonderslug%2Fesphome-ancs%2Fmaster%2Frequirements.txt&search=esphome%3D%3D%28.%2A%29&replace=%241&label=ESPHome&logo=esphome&logoColor=white&color=000000)](requirements.txt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 This is an ESPHome external component that turns an ESP32 into an Apple Notification Center Service (ANCS) consumer. When a bonded iPhone receives a notification — an incoming call, iMessage, app alert, and so on — the ANCS events drive ESPHome automations and sensor entities directly on the device. The component runs on the native NimBLE stack over ESP-IDF; because the ESP32's Bluetooth radio is dedicated to ANCS, it cannot coexist with Bluedroid-based features such as `bluetooth_proxy`, `esp32_ble_tracker`, or `ble_client`.

--- a/components/ancs/__init__.py
+++ b/components/ancs/__init__.py
@@ -203,6 +203,7 @@ async def disconnect_to_code(config, action_id, template_arg, args):
             cv.Required("uid"): cv.templatable(cv.uint32_t),
         }
     ),
+    synchronous=True,
 )
 async def request_attributes_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/packages/ancs-with-sensors.yaml
+++ b/packages/ancs-with-sensors.yaml
@@ -1,7 +1,7 @@
 # ESPHome ANCS Component — package with sensors
 #
-# Includes the component AND pre-wires the binary_sensor and text_sensor
-# platforms. Requires your config to define:
+# Includes the component AND pre-wires the binary_sensor, text_sensor, and
+# button platforms. Requires your config to define:
 #   - id: my_ancs       on the ancs: block
 #   - api: or mqtt:     to surface sensors in Home Assistant
 #
@@ -34,6 +34,8 @@ binary_sensor:
 text_sensor:
   - platform: ancs
     ancs_id: my_ancs
+    connected_device:
+      name: "${friendly_name} Connected iPhone"
     last_title:
       name: "${friendly_name} Last Notification"
     last_message:
@@ -42,3 +44,20 @@ text_sensor:
       name: "${friendly_name} Last Caller"
     last_app_id:
       name: "${friendly_name} Last App"
+
+button:
+  # Forget all paired phones and restart advertising so a new phone can pair.
+  - platform: template
+    name: "${friendly_name} Clear Bonds"
+    icon: "mdi:link-off"
+    entity_category: config
+    on_press:
+      - ancs.clear_bonds: my_ancs
+
+  # Drop the current BLE link; the phone will typically reconnect on its own.
+  - platform: template
+    name: "${friendly_name} Disconnect iPhone"
+    icon: "mdi:bluetooth-off"
+    entity_category: config
+    on_press:
+      - ancs.disconnect: my_ancs


### PR DESCRIPTION
## Summary
- Wire up the `connected_device` text sensor in the `ancs-with-sensors` package — it was defined in the component but never exposed, so the connected iPhone's name was unavailable in Home Assistant.
- Add template buttons for the existing `ancs.clear_bonds` and `ancs.disconnect` actions (marked `entity_category: config`).
- Register the `request_attributes` action as `synchronous`, matching `clear_bonds` and `disconnect`.

## Commits
- `docs`: README badge cleanup
- `feat(package)`: expose `connected_device` sensor + clear-bonds/disconnect buttons
- `fix(ancs)`: register `request_attributes` action as synchronous

## Test plan
- [ ] Flash the `ancs-with-sensors` package and confirm "Connected iPhone" text sensor appears in Home Assistant
- [ ] Verify the Clear Bonds and Disconnect buttons trigger their respective actions