### PR TITLE
feat: add Home Assistant events bridge package and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is an ESPHome external component that turns an ESP32 into an Apple Notifica
 | [Architecture](docs/architecture.md) | Three-layer design, threading model, BLE lifecycle, key design decisions |
 | [App ID reference](docs/app-id-reference.md) | Master lookup table — app name → bundle ID, category, typical title/message content |
 | [Category reference](docs/categories/README.md) | All ANCS notification categories, trigger variables, event flags, common patterns |
+| [Packages reference](docs/packages.md) | All three packages — what each provides, requirements, minimal configs, and HA event payloads |
 
 **Example configurations** (ready to flash on a WEMOS D1 Mini ESP32):
 
@@ -74,6 +75,16 @@ packages:
 ```
 
 The `ancs-with-sensors` package uses `${friendly_name}` for sensor names — define it as a substitution and all sensors are prefixed automatically.
+
+**With Home Assistant events (fire HA events from every notification):**
+
+```yaml
+packages:
+  ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@master
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+```
+
+The `ancs-ha-events` package fires `esphome.ancs_incoming_call`, `esphome.ancs_notification`, and `esphome.ancs_call_ended` events over the native API. Add matching `event` triggers in your HA automations to react without polling sensors. Requires `api:` and `fetch_attributes: [app_id, title, subtitle, message]`. See [docs/packages.md](docs/packages.md) for event payload details and automation examples.
 
 **Pin to a release tag for production (recommended once the repo has releases):**
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,371 @@
+# Packages Reference
+
+This component ships three ESPHome packages that you pull in via the `packages:` key.
+Each package is a self-contained YAML fragment that extends your device config — you
+never need to clone or fork the repository. Use them to get from zero to working
+notifications with minimal boilerplate, or compose them together for a richer setup.
+
+---
+
+## Package overview
+
+| Package | What it provides | Requires |
+|---|---|---|
+| `ancs.yaml` | `external_components` declaration only — the component code itself | Nothing beyond the `packages:` include |
+| `ancs-with-sensors.yaml` | Component code + `binary_sensor`, `text_sensor`, and `button` platforms pre-wired for HA | `substitutions.friendly_name`, `id: my_ancs` on your `ancs:` block, `api:` or `mqtt:` |
+| `ancs-ha-events.yaml` | `on_notification_attributes` and `on_notification_removed` triggers that fire three HA events | `id: my_ancs`, `auto_fetch_attributes: true`, `fetch_attributes: [app_id, title, subtitle, message]`, `api:` |
+
+Packages can be stacked. For example, you can include both `ancs-with-sensors.yaml`
+and `ancs-ha-events.yaml` in the same device config to get both the HA entity sensors
+and the event stream.
+
+---
+
+## `ancs.yaml` — component only
+
+### What it does
+
+Declares the `external_components` block that tells ESPHome to pull the `ancs`
+component from GitHub. This is the foundation that all other packages build on.
+It provides no sensors, no triggers, and no automations — just the component code.
+
+### When to use it
+
+Use `ancs.yaml` when you want full control over every sensor, trigger, and action
+in your own YAML. This is the right choice if you are building device-level automations
+(blinking LEDs, controlling relays) directly in ESPHome and do not want the sensor
+or event packages.
+
+### What it requires
+
+Nothing beyond the `packages:` include itself. You add the `ancs:` block, any
+triggers, and any sensors in your own config.
+
+### Minimal working config
+
+```yaml
+esphome:
+  name: my-ancs-device
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+api:
+ota:
+  - platform: esphome
+
+packages:
+  ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@master
+
+ancs:
+  id: my_ancs
+  name: "My ANCS"
+  on_notification_added:
+    - logger.log:
+        format: "Notification: category=%s uid=%d"
+        args: [category.c_str(), uid]
+```
+
+---
+
+## `ancs-with-sensors.yaml` — component + sensors
+
+### What it does
+
+A standalone package that declares the same `external_components` block as
+`ancs.yaml` and adds pre-wired Home Assistant entities — it does not depend on
+or inherit from `ancs.yaml`:
+
+- **Binary sensors** — `connected` (HA entity: **"[friendly_name] iPhone Connected"**)
+  and `call_active` (HA entity: **"[friendly_name] Call Active"**).
+- **Text sensors:**
+  - `connected_device` → HA entity **"[friendly_name] Connected Device"** — name of the
+    paired iPhone.
+  - `last_title` → HA entity **"[friendly_name] Last Notification"** — the notification
+    title (not "Last Title"; the friendly label is "Last Notification").
+  - `last_message` → HA entity **"[friendly_name] Last Message"** — the notification
+    body text.
+  - `last_caller` → HA entity **"[friendly_name] Last Caller"** — the resolved caller
+    name from the most recent incoming-call notification.
+  - `last_app_id` → HA entity **"[friendly_name] Last App ID"** — the bundle ID of the
+    app that sent the most recent notification.
+- **Buttons** — **"[friendly_name] Clear Bonds"** (removes all BLE bonds and restarts
+  advertising) and **"[friendly_name] Disconnect iPhone"** (drops the current BLE link).
+
+All entity names are prefixed with `${friendly_name}` so they appear cleanly in
+Home Assistant. The internal sensor IDs (e.g. `last_title`) differ from the HA-facing
+names shown above — always look up entities by their friendly name or entity ID in HA,
+not by the YAML key.
+
+### When to use it
+
+Use this package when you want HA entities without writing any sensor YAML by hand.
+It is also a good starting point if you want a quick working setup before adding
+custom triggers.
+
+### What it requires
+
+- `substitutions.friendly_name` — a string used as the entity name prefix.
+- `id: my_ancs` — you must set this on your `ancs:` block exactly as written;
+  the package references it by this ID.
+- `api:` or `mqtt:` — to surface the sensors in Home Assistant.
+
+### Minimal working config
+
+```yaml
+esphome:
+  name: my-ancs-device
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+substitutions:
+  friendly_name: "Living Room"
+
+api:
+ota:
+  - platform: esphome
+
+packages:
+  ancs_component: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
+
+ancs:
+  id: my_ancs
+  name: "Living Room ANCS"
+```
+
+This produces HA entities named `Living Room iPhone Connected`, `Living Room Call Active`,
+`Living Room Last Notification`, and so on.
+
+---
+
+## `ancs-ha-events.yaml` — Home Assistant events
+
+### What it does
+
+Wires `on_notification_attributes` and `on_notification_removed` triggers to fire
+three HA events over the ESPHome native API:
+
+| Event | When it fires | Payload fields |
+|---|---|---|
+| `esphome.ancs_incoming_call` | An incoming call notification has its attributes available | `uid`, `caller`, `app_id`, `device_name` |
+| `esphome.ancs_notification` | Any non-call notification has its attributes available | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name` |
+| `esphome.ancs_call_ended` | An incoming call is declined or answered | `uid`, `device_name` |
+
+### When to use it
+
+Use this package when you want to react to iPhone notifications from Home Assistant
+automations rather than (or in addition to) on-device ESPHome triggers. It offloads
+all notification logic to HA, where you have access to the full automation engine,
+other devices, and more complex conditions.
+
+### What it requires
+
+You must define these in your own config:
+
+- `id: my_ancs` on your `ancs:` block.
+- `auto_fetch_attributes: true` on your `ancs:` block.
+- `fetch_attributes: [app_id, title, subtitle, message]` on your `ancs:` block —
+  the package reads these fields to build event payloads.
+- `api:` — events travel over the ESPHome native API. The device must be connected
+  to Home Assistant.
+
+### Why `on_notification_attributes` instead of `on_notification_added`
+
+`on_notification_added` fires as soon as iOS delivers the 8-byte Notification Source
+record — before any attribute data (title, message, caller name, app ID) is available.
+`on_notification_attributes` fires after the component has fetched and assembled all
+requested attributes via the ANCS Data Source characteristic. The package uses
+`on_notification_attributes` because the event payloads would be empty strings if
+fired earlier.
+
+### `caller` field
+
+`caller` appears only in `esphome.ancs_incoming_call` events. It contains the
+caller's display name as iOS resolves it — typically a contact name such as "Mom"
+or "John Smith", or the raw phone number if the caller is not saved in Contacts.
+
+The value comes from the ANCS `title` attribute for the incoming call notification.
+It is the same string that would be exposed as `title` in an
+`on_notification_attributes` trigger on the device.
+
+### `device_name` field
+
+`device_name` contains the ESPHome device name from the `esphome.name` key in your
+config (retrieved via `App.get_name()`). If you have more than one ANCS device
+paired to Home Assistant, every event from every device arrives under the same
+event type names. Use `trigger.event.data.device_name` in your HA automation
+condition to target events from a specific device.
+
+### `uid` field
+
+`uid` is a decimal string containing the notification UID assigned by iOS. The same
+UID is present in both `esphome.ancs_incoming_call` and the corresponding
+`esphome.ancs_call_ended` event for the same call. Use it in HA automations when
+you need to correlate "this call ended" with "this call started" — for example,
+to cancel a flashing light scene that was triggered by a specific call.
+
+`esphome.ancs_call_ended` fires when the incoming call notification is declined
+or answered. It does not fire for missed calls. Missed calls produce a
+separate notification under the `missed_call` category and arrive as
+`esphome.ancs_notification` with `category: missed_call`.
+
+### Minimal working config
+
+```yaml
+esphome:
+  name: ancs-ha-bridge
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+api:
+ota:
+  - platform: esphome
+
+packages:
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+
+ancs:
+  id: my_ancs
+  name: "ANCS HA Bridge"
+  auto_fetch_attributes: true
+  fetch_attributes: [app_id, title, subtitle, message]
+```
+
+### Home Assistant automation examples
+
+Paste these skeletons into **Settings → Automations → New automation → Edit as YAML**.
+
+#### (a) Flash a light on incoming call
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_incoming_call
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.YOUR_LIGHT
+    data:
+      flash: long
+```
+
+> **Note:** `flash: long` triggers a single flash sequence that stops on its own.
+> To flash continuously until the call ends, use a script with a repeat loop — see
+> the [blink-on-call example](../examples/d1-mini-blink-on-call.yaml) for a pattern
+> you can adapt as an HA script.
+
+#### (b) Stop flashing when the call ends
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_call_ended
+action:
+  - service: light.turn_off
+    target:
+      entity_id: light.YOUR_LIGHT
+```
+
+#### (c) Announce the caller's name via TTS
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_incoming_call
+action:
+  - service: tts.cloud_say
+    data:
+      entity_id: media_player.YOUR_SPEAKER
+      message: "Incoming call from {{ trigger.event.data.caller }}"
+```
+
+> **Note:** `tts.cloud_say` requires a Home Assistant Cloud (Nabu Casa) subscription.
+> If you don't have HA Cloud, use `tts.speak` with your preferred local or cloud TTS
+> provider instead (e.g., Piper, Google TTS). `tts.speak` is available since HA 2023.x
+> and works with any configured TTS integration.
+
+#### (d) Filter by app ID
+
+React only when a specific app sends a notification. See
+[app-id-reference.md](app-id-reference.md) for bundle IDs.
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_notification
+    event_data:
+      app_id: com.apple.MobileSMS
+action:
+  - service: notify.YOUR_NOTIFY_SERVICE
+    data:
+      message: "iMessage from {{ trigger.event.data.title }}: {{ trigger.event.data.message }}"
+```
+
+#### (e) Filter by category
+
+React to all notifications of a given category. See
+[categories/README.md](categories/README.md) for the full category list.
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_notification
+    event_data:
+      category: email
+action:
+  - service: script.announce_email
+    data:
+      sender: "{{ trigger.event.data.title }}"
+      subject: "{{ trigger.event.data.message }}"
+```
+
+---
+
+## Combining packages: `ancs-with-sensors.yaml` + `ancs-ha-events.yaml`
+
+You can include both packages in the same config to get HA entity sensors and the
+event stream simultaneously.
+
+```yaml
+esphome:
+  name: ancs-ha-bridge
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+substitutions:
+  friendly_name: "Living Room"
+
+api:
+ota:
+  - platform: esphome
+
+packages:
+  ancs_sensors:    github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
+  ancs_ha_events:  github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+
+ancs:
+  id: my_ancs
+  name: "Living Room ANCS"
+  auto_fetch_attributes: true
+  fetch_attributes: [app_id, title, subtitle, message]
+```
+
+`ancs-with-sensors.yaml` already declares `external_components`, so you do not
+also need `ancs.yaml` — the sensors package is a superset of it.
+
+Both packages reference `id: my_ancs`, so the single `ancs:` block satisfies both.
+The `fetch_attributes` list must include all four attributes (`app_id`, `title`,
+`subtitle`, `message`) because `ancs-ha-events.yaml` requires them for event payloads.
+`ancs-with-sensors.yaml` does not care about `fetch_attributes` — its text sensors
+are updated on every notification regardless.

--- a/examples/ha-events.yaml
+++ b/examples/ha-events.yaml
@@ -1,0 +1,132 @@
+# Home Assistant Events Example
+# ─────────────────────────────────────────────────────────────────────────────
+# Demonstrates using the ancs-ha-events package to fire HA events from iPhone
+# notifications. Flash this config, pair via nRF Connect (see README), and
+# configure matching automations in Home Assistant.
+#
+# Three events are fired automatically by the included package:
+#
+#   esphome.ancs_incoming_call  — when an incoming call's attributes arrive
+#   esphome.ancs_notification   — when any non-call notification's attributes arrive
+#   esphome.ancs_call_ended     — when the incoming call is dismissed or answered
+#
+# ─── Home Assistant automation skeletons ─────────────────────────────────────
+#
+# Paste these into Home Assistant → Settings → Automations → New → Edit as YAML
+#
+# 1. Flash a light on incoming call:
+#
+#   trigger:
+#     - platform: event
+#       event_type: esphome.ancs_incoming_call
+#   action:
+#     - service: light.turn_on
+#       target:
+#         entity_id: light.YOUR_LIGHT
+#       data:
+#         flash: long
+#
+# 2. Stop flashing when the call ends:
+#
+#   trigger:
+#     - platform: event
+#       event_type: esphome.ancs_call_ended
+#   action:
+#     - service: light.turn_off
+#       target:
+#         entity_id: light.YOUR_LIGHT
+#
+# 3. Announce the caller's name via TTS:
+#
+#   trigger:
+#     - platform: event
+#       event_type: esphome.ancs_incoming_call
+#   action:
+#     - service: tts.cloud_say
+#       data:
+#         entity_id: media_player.YOUR_SPEAKER
+#         message: "Incoming call from {{ trigger.event.data.caller }}"
+#
+# 4. React to a specific app notification (filter by app_id):
+#
+#   trigger:
+#     - platform: event
+#       event_type: esphome.ancs_notification
+#       event_data:
+#         app_id: com.apple.MobileSMS
+#   action:
+#     - service: notify.YOUR_NOTIFY_SERVICE
+#       data:
+#         message: "iMessage from {{ trigger.event.data.title }}: {{ trigger.event.data.message }}"
+#
+# 5. React to a notification category:
+#
+#   trigger:
+#     - platform: event
+#       event_type: esphome.ancs_notification
+#       event_data:
+#         category: email  # valid categories: other, incoming_call, missed_call, voicemail, social, schedule, email, news, health_fitness, business_finance, location, entertainment
+#   action:
+#     - service: script.announce_email
+#       data:
+#         sender: "{{ trigger.event.data.title }}"
+#         subject: "{{ trigger.event.data.message }}"
+#
+# See docs/app-id-reference.md for a full list of iOS app bundle IDs.
+# ─────────────────────────────────────────────────────────────────────────────
+
+esphome:
+  name: ancs-ha-bridge
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: INFO
+
+# api: is required — events travel over the ESPHome native API.
+# For production, uncomment the encryption block and paste the key from
+# the ESPHome add-on in Home Assistant (Settings → Add-ons → ESPHome → key icon).
+api:
+  # encryption:
+  #   key: "your-32-byte-base64-key-from-ha-esphome-addon"
+
+ota:
+  - platform: esphome
+    password: ""
+
+# For local development, use the local path. For production, switch to the
+# GitHub source below and comment out the local block.
+external_components:
+  - source:
+      type: local
+      path: ../components
+  # Production:
+  # - source:
+  #     type: git
+  #     url: https://github.com/wonderslug/esphome-ancs
+  #     ref: master
+  #   components: [ancs]
+
+# ─── ANCS ────────────────────────────────────────────────────────────────────
+ancs:
+  id: my_ancs
+  name: "ANCS HA Bridge"       # shown in iOS when pairing via nRF Connect
+  auto_fetch_attributes: true
+  # Must include all attributes the package uses for event payloads.
+  fetch_attributes: [app_id, title, subtitle, message]
+
+# ─── Package ─────────────────────────────────────────────────────────────────
+# Wires on_notification_attributes and on_notification_removed to HA events.
+# For production with GitHub source, use:
+#   ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+packages:
+  ancs_ha_events: !include ../packages/ancs-ha-events.yaml
+
+# ─── Network ─────────────────────────────────────────────────────────────────
+# Add your wifi or ethernet config here. Example:
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -1,0 +1,64 @@
+# ESPHome ANCS Component — Home Assistant events package
+#
+# Fires three HA events when iPhone notifications arrive via ANCS:
+#
+#   esphome.ancs_incoming_call  — incoming call; payload: uid, caller, app_id, device_name
+#   esphome.ancs_notification   — all other categories; payload: uid, category, app_id,
+#                                 title, subtitle, message, device_name
+#   esphome.ancs_call_ended     — call dismissed or answered; payload: uid, device_name
+#
+# Requirements:
+#   - ancs: block in your main config with:
+#       id: my_ancs
+#       auto_fetch_attributes: true
+#       fetch_attributes: [app_id, title, subtitle, message]  # title = caller name for incoming calls
+#   - api: configured in your main config (events travel over the ESPHome API)
+#
+# Usage (GitHub — recommended):
+#   packages:
+#     ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+#
+# Pin to a release for production:
+#   packages:
+#     ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@v1.0.0
+#
+# Local development:
+#   packages:
+#     ancs_ha_events: !include packages/ancs-ha-events.yaml
+
+ancs:
+  on_notification_attributes:
+    - if:
+        condition:
+          lambda: 'return category == "incoming_call";'
+        then:
+          - homeassistant.event:
+              event: esphome.ancs_incoming_call
+              data:
+                uid: !lambda 'return std::to_string(uid);'
+                caller: !lambda 'return title;'
+                app_id: !lambda 'return app_id;'
+                device_name: !lambda 'return std::string(App.get_name());'
+        else:
+          - homeassistant.event:
+              event: esphome.ancs_notification
+              data:
+                uid: !lambda 'return std::to_string(uid);'
+                category: !lambda 'return category;'
+                app_id: !lambda 'return app_id;'
+                title: !lambda 'return title;'
+                subtitle: !lambda 'return subtitle;'
+                message: !lambda 'return message;'
+                device_name: !lambda 'return std::string(App.get_name());'
+
+  # Only incoming_call removals fire an event; other notification removals are intentionally ignored.
+  on_notification_removed:
+    - if:
+        condition:
+          lambda: 'return category == "incoming_call";'
+        then:
+          - homeassistant.event:
+              event: esphome.ancs_call_ended
+              data:
+                uid: !lambda 'return std::to_string(uid);'
+                device_name: !lambda 'return std::string(App.get_name());'


### PR DESCRIPTION
## Summary

- Adds `packages/ancs-ha-events.yaml` — a drop-in package that fires three HA events from ANCS triggers over the native ESPHome API, requiring no C++ changes
- Adds `examples/ha-events.yaml` — full device config demonstrating the package with five annotated HA automation skeletons
- Adds `docs/packages.md` — detailed reference for all three packages (what each provides, requirements, minimal configs, event payloads, automation examples)
- Updates `README.md` with the new package entry in the installation section and a link to the packages reference

## Events fired

| Event | When | Key payload fields |
|---|---|---|
| `esphome.ancs_incoming_call` | Incoming call attributes arrive | `uid`, `caller`, `app_id`, `device_name` |
| `esphome.ancs_notification` | Any non-call notification attributes arrive | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name` |
| `esphome.ancs_call_ended` | Incoming call declined or answered | `uid`, `device_name` |

> **Note:** ESPHome 2026.5.1 requires custom event names to start with `esphome.` — all three events carry that prefix.

## How it works

The package adds `on_notification_attributes` and `on_notification_removed` automation blocks to the `ancs:` component via ESPHome's YAML merge. No `external_components` block or `id:` needed in the package — those come from the user's main config.

`on_notification_attributes` is used (not `on_notification_added`) so the caller name, title, and message body are available in the same event payload without a second event.

## Test plan

- [ ] Flash device with `examples/ha-events.yaml` and pair via nRF Connect
- [ ] Trigger an incoming call — verify `esphome.ancs_incoming_call` fires in HA developer tools with correct `caller`, `app_id`, `uid`, `device_name`
- [ ] Decline/answer the call — verify `esphome.ancs_call_ended` fires with matching `uid`
- [ ] Receive a non-call notification — verify `esphome.ancs_notification` fires with correct `category`, `title`, `message`
- [ ] Combine with `ancs-with-sensors.yaml` — verify both packages merge without conflict
- [ ] `esphome config localdev/ha-events-test.yaml` passes clean