### PR TITLE
feat: add iphone_name to HA event payloads

### DIFF
--- a/components/ancs/ancs_component.cpp
+++ b/components/ancs/ancs_component.cpp
@@ -33,6 +33,7 @@ void AncsComponent::loop() {
     switch (ev.type) {
       case BleEventType::CONNECTED:
         ESP_LOGI(TAG, "iPhone connected: %s", ev.device_name.c_str());
+        connected_device_name_ = ev.device_name;
 #ifdef USE_BINARY_SENSOR
         if (connected_bs_)
           connected_bs_->publish_state(true);
@@ -45,6 +46,7 @@ void AncsComponent::loop() {
         break;
       case BleEventType::DISCONNECTED:
         ESP_LOGI(TAG, "iPhone disconnected");
+        connected_device_name_ = "";
 #ifdef USE_BINARY_SENSOR
         if (connected_bs_)
           connected_bs_->publish_state(false);

--- a/components/ancs/ancs_component.h
+++ b/components/ancs/ancs_component.h
@@ -65,6 +65,7 @@ class AncsComponent : public Component {
   void clear_bonds() { ble_.clear_bonds_and_restart(); }
   void disconnect() { ble_.disconnect(); }
   void request_attributes(uint32_t uid) { ble_.request_attributes(uid); }
+  const std::string &get_connected_device_name() const { return connected_device_name_; }
 
  protected:
   AncsBle ble_;
@@ -75,6 +76,7 @@ class AncsComponent : public Component {
   uint8_t max_bonds_{3};
   std::vector<protocol::AttributeId> fetch_attrs_;
   bool call_active_{false};
+  std::string connected_device_name_;
 
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *connected_bs_{nullptr};

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -152,9 +152,9 @@ three HA events over the ESPHome native API:
 
 | Event | When it fires | Payload fields |
 |---|---|---|
-| `esphome.ancs_incoming_call` | An incoming call notification has its attributes available | `uid`, `caller`, `app_id`, `device_name` |
-| `esphome.ancs_notification` | Any non-call notification has its attributes available | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name` |
-| `esphome.ancs_call_ended` | An incoming call is declined or answered | `uid`, `device_name` |
+| `esphome.ancs_incoming_call` | An incoming call notification has its attributes available | `uid`, `caller`, `app_id`, `device_name`, `iphone_name` |
+| `esphome.ancs_notification` | Any non-call notification has its attributes available | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name`, `iphone_name` |
+| `esphome.ancs_call_ended` | An incoming call is declined or answered | `uid`, `device_name`, `iphone_name` |
 
 ### When to use it
 
@@ -200,6 +200,19 @@ config (retrieved via `App.get_name()`). If you have more than one ANCS device
 paired to Home Assistant, every event from every device arrives under the same
 event type names. Use `trigger.event.data.device_name` in your HA automation
 condition to target events from a specific device.
+
+### `iphone_name` field
+
+`iphone_name` contains the display name of the connected iPhone as iOS advertises
+it over Bluetooth — typically something like "Brian's iPhone" or "iPhone". It is
+the same name shown in iOS Settings → General → About → Name.
+
+The value is set when the iPhone connects and cleared to an empty string when it
+disconnects. Because events only fire while a device is connected, `iphone_name`
+will always be non-empty in practice.
+
+If you have more than one ANCS device paired, `iphone_name` identifies which phone
+sent the notification (while `device_name` identifies which ESP32 fired the event).
 
 ### `uid` field
 

--- a/examples/ha-events.yaml
+++ b/examples/ha-events.yaml
@@ -45,7 +45,7 @@
 #     - service: tts.cloud_say
 #       data:
 #         entity_id: media_player.YOUR_SPEAKER
-#         message: "Incoming call from {{ trigger.event.data.caller }}"
+#         message: "Incoming call from {{ trigger.event.data.caller }} on {{ trigger.event.data.iphone_name }}"
 #
 # 4. React to a specific app notification (filter by app_id):
 #

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -2,10 +2,10 @@
 #
 # Fires three HA events when iPhone notifications arrive via ANCS:
 #
-#   esphome.ancs_incoming_call  — incoming call; payload: uid, caller, app_id, device_name
+#   esphome.ancs_incoming_call  — incoming call; payload: uid, caller, app_id, device_name, iphone_name
 #   esphome.ancs_notification   — all other categories; payload: uid, category, app_id,
-#                                 title, subtitle, message, device_name
-#   esphome.ancs_call_ended     — call dismissed or answered; payload: uid, device_name
+#                                 title, subtitle, message, device_name, iphone_name
+#   esphome.ancs_call_ended     — call declined or answered; payload: uid, device_name, iphone_name
 #
 # Requirements:
 #   - ancs: block in your main config with:
@@ -28,6 +28,16 @@
 
 ancs:
   on_notification_attributes:
+    - logger.log:
+        format: "ATTRS     uid=%u  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s"
+        tag: "ancs.notification_attrs"
+        args:
+          - uid
+          - category.c_str()
+          - app_id.c_str()
+          - title.c_str()
+          - subtitle.c_str()
+          - message.c_str()
     - if:
         condition:
           lambda: 'return category == "incoming_call";'
@@ -39,6 +49,7 @@ ancs:
                 caller: !lambda 'return title;'
                 app_id: !lambda 'return app_id;'
                 device_name: !lambda 'return std::string(App.get_name());'
+                iphone_name: !lambda 'return id(my_ancs).get_connected_device_name();'
         else:
           - homeassistant.event:
               event: esphome.ancs_notification
@@ -50,6 +61,7 @@ ancs:
                 subtitle: !lambda 'return subtitle;'
                 message: !lambda 'return message;'
                 device_name: !lambda 'return std::string(App.get_name());'
+                iphone_name: !lambda 'return id(my_ancs).get_connected_device_name();'
 
   # Only incoming_call removals fire an event; other notification removals are intentionally ignored.
   on_notification_removed:
@@ -62,3 +74,4 @@ ancs:
               data:
                 uid: !lambda 'return std::to_string(uid);'
                 device_name: !lambda 'return std::string(App.get_name());'
+                iphone_name: !lambda 'return id(my_ancs).get_connected_device_name();'

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -65,6 +65,12 @@ ancs:
 
   # Only incoming_call removals fire an event; other notification removals are intentionally ignored.
   on_notification_removed:
+    - logger.log:
+        format: "REMOVED   uid=%u  cat=%-16s"
+        tag: "ancs.notification_removed"
+        args:
+          - uid
+          - category.c_str()
     - if:
         condition:
           lambda: 'return category == "incoming_call";'


### PR DESCRIPTION
## Summary

- Adds `iphone_name` field to all three HA events fired by `packages/ancs-ha-events.yaml`
- Adds `get_connected_device_name()` public getter to `AncsComponent` (stored on BLE connect, cleared on disconnect)
- Adds `logger.log` of notification attributes to the package for easier debugging
- Updates `docs/packages.md` with payload table and `iphone_name` field description
- Updates `examples/ha-events.yaml` TTS skeleton to demonstrate the field

## Updated event payloads

| Event | New fields |
|---|---|
| `esphome.ancs_incoming_call` | + `iphone_name` |
| `esphome.ancs_notification` | + `iphone_name` |
| `esphome.ancs_call_ended` | + `iphone_name` |

`iphone_name` contains the iPhone's display name (e.g. "Brian's iPhone") as advertised over BLE. Complements the existing `device_name` field (which identifies the ESP32 device) when multiple ANCS devices are paired.

## Test plan

- [x] Flash `examples/ha-events.yaml` and pair via nRF Connect
- [x] Trigger incoming call — verify `esphome.ancs_incoming_call` fires with correct `iphone_name` value
- [x] Receive a notification — verify `esphome.ancs_notification` includes `iphone_name`
- [x] Decline call — verify `esphome.ancs_call_ended` includes `iphone_name`
- [x] `esphome config localdev/ha-events-test.yaml` passes clean