### PR TITLE
feat: make packages standalone, add quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,18 @@ This is an ESPHome external component that turns an ESP32 into an Apple Notifica
 
 ### Via ESPHome packages (recommended)
 
-The simplest way to use the component in any project. Add one line to your YAML — ESPHome fetches the component automatically at compile time.
+The simplest way to use the component in any project. ESPHome fetches the component automatically at compile time.
 
-**Minimal (component code only — you configure everything):**
+> New here? The **[quick start guide](docs/quickstart.md)** gets you from zero to HA automations in under 10 minutes.
+
+**Home Assistant events (quickest path — fires HA events from every notification):**
 
 ```yaml
 packages:
-  ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@master
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
 ```
+
+One package. Add your `esphome:`, ESP32, `wifi:`, `api:`, and `ota:` blocks — nothing else required. See the [quick start guide](docs/quickstart.md) for a copy-paste config and your first HA automation.
 
 **With sensors pre-wired (binary + text sensors appear in Home Assistant automatically):**
 
@@ -71,26 +75,25 @@ substitutions:
   friendly_name: "Living Room"
 
 packages:
-  ancs_component: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
+  ancs_sensors: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
 ```
 
-The `ancs-with-sensors` package uses `${friendly_name}` for sensor names — define it as a substitution and all sensors are prefixed automatically.
+The `ancs-with-sensors` package uses `${friendly_name}` for sensor names — define it as a substitution and all sensors are prefixed automatically. No `ancs:` block needed.
 
-**With Home Assistant events (fire HA events from every notification):**
+**Minimal / custom (component code only — you configure everything):**
 
 ```yaml
 packages:
   ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@master
-  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
 ```
 
-The `ancs-ha-events` package fires `esphome.ancs_incoming_call`, `esphome.ancs_notification`, and `esphome.ancs_call_ended` events over the native API. Add matching `event` triggers in your HA automations to react without polling sensors. Requires `api:` and `fetch_attributes: [app_id, title, subtitle, message]`. See [docs/packages.md](docs/packages.md) for event payload details and automation examples.
+Use this when you want full control over every sensor, trigger, and action in your own YAML — device-level automations, custom logic, anything beyond what the other packages provide.
 
 **Pin to a release tag for production (recommended once the repo has releases):**
 
 ```yaml
 packages:
-  ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@v1.0.0
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@v1.0.0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ device is in range with no further use of nRF Connect required.
 3. Open nRF Connect → **SCANNER** tab → tap **SCAN**.
 4. Find your device by the BLE name you set (e.g. `ESPHome-ANCS`) and tap **CONNECT**.
 5. The ESP32 receives the connection and immediately requests pairing. iOS shows a system dialog: **"ESPHome-ANCS" Would Like to Pair With Your iPhone** → tap **Pair**.
-6. nRF Connect shows the GATT services being discovered. You will see the ANCS service appear (`7905F431-…`).
-7. Close nRF Connect. The bond is now stored at the iOS system level.
-8. The ESP32 logs show `ANCS chars done` and `iPhone connected`. ESPHome sensors reflect the connected state.
-9. From this point on iOS reconnects automatically — nRF Connect is no longer needed unless you need to re-pair.
+6. iOS shows a second dialog: **Allow "ESPHome-ANCS" to Receive Your iPhone Notifications?** → tap **Allow**. This grants ANCS access.
+7. nRF Connect shows the GATT services being discovered. You will see the ANCS service appear (`7905F431-…`).
+8. Close nRF Connect. The bond is now stored at the iOS system level.
+9. The ESP32 logs show `ANCS chars done` and `iPhone connected`. ESPHome sensors reflect the connected state.
+10. From this point on iOS reconnects automatically — nRF Connect is no longer needed unless you need to re-pair.
 
 ### Re-pairing after "Forget This Device"
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -81,7 +81,7 @@ or inherit from `ancs.yaml`:
 - **Binary sensors** — `connected` (HA entity: **"[friendly_name] iPhone Connected"**)
   and `call_active` (HA entity: **"[friendly_name] Call Active"**).
 - **Text sensors:**
-  - `connected_device` → HA entity **"[friendly_name] Connected Device"** — name of the
+  - `connected_device` → HA entity **"[friendly_name] Connected iPhone"** — name of the
     paired iPhone.
   - `last_title` → HA entity **"[friendly_name] Last Notification"** — the notification
     title (not "Last Title"; the friendly label is "Last Notification").

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -12,8 +12,8 @@ notifications with minimal boilerplate, or compose them together for a richer se
 | Package | What it provides | Requires |
 |---|---|---|
 | `ancs.yaml` | `external_components` declaration only — the component code itself | Nothing beyond the `packages:` include |
-| `ancs-with-sensors.yaml` | Component code + `binary_sensor`, `text_sensor`, and `button` platforms pre-wired for HA | `substitutions.friendly_name`, `id: my_ancs` on your `ancs:` block, `api:` or `mqtt:` |
-| `ancs-ha-events.yaml` | `on_notification_attributes` and `on_notification_removed` triggers that fire three HA events | `id: my_ancs`, `auto_fetch_attributes: true`, `fetch_attributes: [app_id, title, subtitle, message]`, `api:` |
+| `ancs-with-sensors.yaml` | Component code + `binary_sensor`, `text_sensor`, and `button` platforms pre-wired for HA | `substitutions.friendly_name`, `api:` or `mqtt:` |
+| `ancs-ha-events.yaml` | Everything needed to fire three HA events from iPhone notifications — component, ANCS config, and event triggers | `api:` |
 
 Packages can be stacked. For example, you can include both `ancs-with-sensors.yaml`
 and `ancs-ha-events.yaml` in the same device config to get both the HA entity sensors
@@ -107,10 +107,11 @@ custom triggers.
 
 ### What it requires
 
-- `substitutions.friendly_name` — a string used as the entity name prefix.
-- `id: my_ancs` — you must set this on your `ancs:` block exactly as written;
-  the package references it by this ID.
+- `substitutions.friendly_name` — a string used as the entity name prefix for all HA entities.
 - `api:` or `mqtt:` — to surface the sensors in Home Assistant.
+
+**Optional substitution:**
+- `ancs_name` (default: `"ANCS HA Bridge"`) — the BLE name shown in nRF Connect during pairing. Override it in your own `substitutions:` block if you want a custom pairing name.
 
 ### Minimal working config
 
@@ -125,21 +126,23 @@ esp32:
 
 substitutions:
   friendly_name: "Living Room"
+  # ancs_name: "Living Room ANCS"   # optional — overrides BLE pairing name
 
 api:
 ota:
   - platform: esphome
 
-packages:
-  ancs_component: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
 
-ancs:
-  id: my_ancs
-  name: "Living Room ANCS"
+packages:
+  ancs_sensors: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
 ```
 
 This produces HA entities named `Living Room iPhone Connected`, `Living Room Call Active`,
-`Living Room Last Notification`, and so on.
+`Living Room Last Notification`, and so on. No `ancs:` block is needed — the package
+provides the base configuration.
 
 ---
 
@@ -165,14 +168,14 @@ other devices, and more complex conditions.
 
 ### What it requires
 
-You must define these in your own config:
-
-- `id: my_ancs` on your `ancs:` block.
-- `auto_fetch_attributes: true` on your `ancs:` block.
-- `fetch_attributes: [app_id, title, subtitle, message]` on your `ancs:` block —
-  the package reads these fields to build event payloads.
 - `api:` — events travel over the ESPHome native API. The device must be connected
   to Home Assistant.
+
+The package provides everything else: the component code, the `ancs:` base configuration
+(`id`, `auto_fetch_attributes`, `fetch_attributes`), and the event trigger wiring.
+
+**Optional substitution:**
+- `ancs_name` (default: `"ANCS HA Bridge"`) — the BLE name shown in nRF Connect during pairing. Override it in your own `substitutions:` block if you want a custom pairing name.
 
 ### Why `on_notification_attributes` instead of `on_notification_added`
 
@@ -238,19 +241,23 @@ esp32:
   framework:
     type: esp-idf
 
+# substitutions:
+#   ancs_name: "My iPhone Bridge"   # optional — overrides BLE pairing name
+
 api:
 ota:
   - platform: esphome
 
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
 packages:
   ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
-
-ancs:
-  id: my_ancs
-  name: "ANCS HA Bridge"
-  auto_fetch_attributes: true
-  fetch_attributes: [app_id, title, subtitle, message]
 ```
+
+No `ancs:` block is needed — the package provides the base configuration. The only required
+setting in your own config is `api:`.
 
 ### Home Assistant automation examples
 
@@ -345,7 +352,8 @@ action:
 ## Combining packages: `ancs-with-sensors.yaml` + `ancs-ha-events.yaml`
 
 You can include both packages in the same config to get HA entity sensors and the
-event stream simultaneously.
+event stream simultaneously. Both packages are self-contained, so no manual `ancs:`
+block is needed.
 
 ```yaml
 esphome:
@@ -358,27 +366,26 @@ esp32:
 
 substitutions:
   friendly_name: "Living Room"
+  # ancs_name: "Living Room ANCS"   # optional — overrides BLE pairing name
 
 api:
 ota:
   - platform: esphome
 
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
 packages:
   ancs_sensors:    github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
   ancs_ha_events:  github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
-
-ancs:
-  id: my_ancs
-  name: "Living Room ANCS"
-  auto_fetch_attributes: true
-  fetch_attributes: [app_id, title, subtitle, message]
 ```
 
-`ancs-with-sensors.yaml` already declares `external_components`, so you do not
-also need `ancs.yaml` — the sensors package is a superset of it.
+Both packages define `ancs: id: my_ancs` — ESPHome deep-merges these into one block,
+so there is no conflict. Both packages also define `substitutions: ancs_name: "ANCS HA Bridge"`;
+since the key and value are identical, there is no conflict there either. Override `ancs_name`
+once in your own `substitutions:` block and both packages pick it up.
 
-Both packages reference `id: my_ancs`, so the single `ancs:` block satisfies both.
-The `fetch_attributes` list must include all four attributes (`app_id`, `title`,
-`subtitle`, `message`) because `ancs-ha-events.yaml` requires them for event payloads.
-`ancs-with-sensors.yaml` does not care about `fetch_attributes` — its text sensors
-are updated on every notification regardless.
+`ancs-with-sensors.yaml` does not require `fetch_attributes` — its text sensors are updated
+on every notification regardless. `ancs-ha-events.yaml` sets `fetch_attributes` internally,
+so you do not need to specify it.

--- a/docs/pairing.md
+++ b/docs/pairing.md
@@ -106,16 +106,20 @@ on both sides as long as neither side deliberately deletes it.
 5. **The iOS pairing dialog appears** — a system prompt reading something like:
    *"ESPHome-ANCS" Would Like to Pair With Your iPhone*. Tap **Pair**.
 
-6. nRF Connect will display the GATT service discovery results. After a few
+6. **A second iOS dialog appears** — *Allow "ESPHome-ANCS" to Receive Your iPhone
+   Notifications?* Tap **Allow**. This grants the ANCS permission; without it the
+   component connects but receives no notifications.
+
+7. nRF Connect will display the GATT service discovery results. After a few
    seconds you will see the ANCS service (`7905F431-B5CE-4E99-A40F-4B1E122D00D0`)
    and its three characteristics appear in the list. This confirms the bond was
    accepted and ANCS discovery succeeded.
 
-7. **Close nRF Connect.** You do not need to keep it open. The bond is stored
+8. **Close nRF Connect.** You do not need to keep it open. The bond is stored
    at the iOS system level and the ANCS connection persists (or will
    auto-reconnect if nRF Connect dropped it when closed).
 
-8. Check the ESP32 serial log. You should see:
+9. Check the ESP32 serial log. You should see:
    ```
    [I][ancs.ble]: encrypted — starting ANCS service discovery
    [I][ancs.ble]: ANCS chars done: ns=XX cp=XX ds=XX

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,112 @@
+# Quick Start: iPhone Notifications in Home Assistant
+
+Get iPhone notifications flowing as Home Assistant events in under 10 minutes.
+No sensors to configure. No custom triggers to write. One package, a wifi config, and you're done.
+
+---
+
+## What you need
+
+- Any ESP32 board (tested with `esp32dev`; a WEMOS D1 Mini ESP32 works great)
+- [ESPHome](https://esphome.io/guides/getting_started_hassio) installed (add-on or CLI)
+- [nRF Connect for Mobile](https://apps.apple.com/app/nrf-connect-for-mobile/id1054362403) installed on your iPhone (free, required for the initial pairing — see [why](pairing.md))
+- Home Assistant with the ESPHome integration added
+
+---
+
+## The config
+
+Create a new file — call it `ancs-ha-bridge.yaml` — and paste this in:
+
+```yaml
+esphome:
+  name: ancs-ha-bridge
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+# substitutions:
+#   ancs_name: "My iPhone Bridge"   # optional — name shown in nRF Connect when pairing
+
+api:
+  # encryption:
+  #   key: "your-32-byte-base64-key-from-ha-esphome-addon"
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+packages:
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+```
+
+That's the entire config. The package handles the component, the ANCS configuration, and the HA event wiring.
+
+---
+
+## Flash and pair
+
+1. Flash the config: `esphome run ancs-ha-bridge.yaml` (or use the ESPHome add-on dashboard).
+2. Watch the log for `NimBLE synced` and `advertising started`.
+3. On your iPhone, open **nRF Connect** → **SCANNER** tab → tap **SCAN**.
+4. Find `ANCS HA Bridge` in the list and tap **CONNECT**.
+5. iOS shows a system dialog: **"ANCS HA Bridge" Would Like to Pair** → tap **Pair**.
+6. Close nRF Connect. The bond is stored at the iOS system level.
+7. The ESP32 log shows `ANCS chars done` and `iPhone connected`. You're paired.
+
+From this point iOS reconnects automatically whenever the ESP32 is powered on and in range — nRF Connect is only needed for the first pairing.
+
+> **Stuck?** See the full [pairing guide](pairing.md) for troubleshooting, re-pairing after "Forget This Device", and why Settings → Bluetooth doesn't work.
+
+---
+
+## Your first automation
+
+In Home Assistant go to **Settings → Automations → New automation → Edit as YAML** and paste:
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_incoming_call
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.YOUR_LIGHT
+    data:
+      flash: long
+```
+
+Replace `light.YOUR_LIGHT` with any light entity in your home. Save and test it by calling yourself — the light flashes when the call arrives.
+
+### Stop flashing when the call ends
+
+Add a second automation:
+
+```yaml
+trigger:
+  - platform: event
+    event_type: esphome.ancs_call_ended
+action:
+  - service: light.turn_off
+    target:
+      entity_id: light.YOUR_LIGHT
+```
+
+---
+
+## What's next
+
+Three events are available:
+
+| Event | When | Key payload fields |
+|---|---|---|
+| `esphome.ancs_incoming_call` | Incoming call arrives | `caller`, `app_id`, `iphone_name`, `device_name` |
+| `esphome.ancs_notification` | Any other notification | `category`, `title`, `message`, `app_id`, `iphone_name`, `device_name` |
+| `esphome.ancs_call_ended` | Call answered or declined | `uid`, `iphone_name`, `device_name` |
+
+See [docs/packages.md](packages.md) for all payload fields, more automation examples (TTS, filtering by app ID, filtering by category), and how to add HA entity sensors alongside events.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,8 +56,9 @@ That's the entire config. The package handles the component, the ANCS configurat
 3. On your iPhone, open **nRF Connect** → **SCANNER** tab → tap **SCAN**.
 4. Find `ANCS HA Bridge` in the list and tap **CONNECT**.
 5. iOS shows a system dialog: **"ANCS HA Bridge" Would Like to Pair** → tap **Pair**.
-6. Close nRF Connect. The bond is stored at the iOS system level.
-7. The ESP32 log shows `ANCS chars done` and `iPhone connected`. You're paired.
+6. iOS shows a second dialog: **Allow "ANCS HA Bridge" to Receive Your iPhone Notifications?** → tap **Allow**. This is what grants ANCS access.
+7. Close nRF Connect. The bond is stored at the iOS system level.
+8. The ESP32 log shows `ANCS chars done` and `iPhone connected`. You're paired.
 
 From this point iOS reconnects automatically whenever the ESP32 is powered on and in range — nRF Connect is only needed for the first pairing.
 

--- a/examples/ha-events.yaml
+++ b/examples/ha-events.yaml
@@ -86,6 +86,9 @@ esp32:
 logger:
   level: INFO
 
+# substitutions:
+#   ancs_name: "My iPhone Bridge"   # optional — overrides the BLE pairing name
+
 # api: is required — events travel over the ESPHome native API.
 # For production, uncomment the encryption block and paste the key from
 # the ESPHome add-on in Home Assistant (Settings → Add-ons → ESPHome → key icon).
@@ -97,36 +100,16 @@ ota:
   - platform: esphome
     password: ""
 
-# For local development, use the local path. For production, switch to the
-# GitHub source below and comment out the local block.
-external_components:
-  - source:
-      type: local
-      path: ../components
-  # Production:
-  # - source:
-  #     type: git
-  #     url: https://github.com/wonderslug/esphome-ancs
-  #     ref: master
-  #   components: [ancs]
-
-# ─── ANCS ────────────────────────────────────────────────────────────────────
-ancs:
-  id: my_ancs
-  name: "ANCS HA Bridge"       # shown in iOS when pairing via nRF Connect
-  auto_fetch_attributes: true
-  # Must include all attributes the package uses for event payloads.
-  fetch_attributes: [app_id, title, subtitle, message]
-
-# ─── Package ─────────────────────────────────────────────────────────────────
-# Wires on_notification_attributes and on_notification_removed to HA events.
-# For production with GitHub source, use:
-#   ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
-packages:
-  ancs_ha_events: !include ../packages/ancs-ha-events.yaml
-
 # ─── Network ─────────────────────────────────────────────────────────────────
 # Add your wifi or ethernet config here. Example:
 # wifi:
 #   ssid: !secret wifi_ssid
 #   password: !secret wifi_password
+
+# ─── Package ─────────────────────────────────────────────────────────────────
+packages:
+  ancs_ha_events: github://wonderslug/esphome-ancs/packages/ancs-ha-events.yaml@master
+
+# For local development, swap the line above for:
+# packages:
+#   ancs_ha_events: !include ../packages/ancs-ha-events.yaml

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -7,11 +7,9 @@
 #                                 title, subtitle, message, device_name, iphone_name
 #   esphome.ancs_call_ended     — call declined or answered; payload: uid, device_name, iphone_name
 #
+# Standalone package — no other packages required. Include it and add your connectivity config.
+#
 # Requirements:
-#   - ancs: block in your main config with:
-#       id: my_ancs
-#       auto_fetch_attributes: true
-#       fetch_attributes: [app_id, title, subtitle, message]  # title = caller name for incoming calls
 #   - api: configured in your main config (events travel over the ESPHome API)
 #
 # Usage (GitHub — recommended):
@@ -25,8 +23,26 @@
 # Local development:
 #   packages:
 #     ancs_ha_events: !include packages/ancs-ha-events.yaml
+#
+# Override the BLE pairing name (shown in nRF Connect when pairing):
+#   substitutions:
+#     ancs_name: "My iPhone Bridge"
+
+substitutions:
+  ancs_name: "ANCS HA Bridge"
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/wonderslug/esphome-ancs
+      ref: master
+    components: [ancs]
 
 ancs:
+  id: my_ancs
+  name: "${ancs_name}"
+  auto_fetch_attributes: true
+  fetch_attributes: [app_id, title, subtitle, message]
   on_notification_attributes:
     - logger.log:
         format: "ATTRS     uid=%u  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s"

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -27,15 +27,20 @@
 # Override the BLE pairing name (shown in nRF Connect when pairing):
 #   substitutions:
 #     ancs_name: "My iPhone Bridge"
+#
+# Override the component ref (useful for development or feature branches):
+#   substitutions:
+#     ancs_ref: "feat/my-branch"
 
 substitutions:
   ancs_name: "ANCS HA Bridge"
+  ancs_ref: "master"
 
 external_components:
   - source:
       type: git
       url: https://github.com/wonderslug/esphome-ancs
-      ref: master
+      ref: "${ancs_ref}"
     components: [ancs]
 
 ancs:

--- a/packages/ancs-with-sensors.yaml
+++ b/packages/ancs-with-sensors.yaml
@@ -1,20 +1,21 @@
 # ESPHome ANCS Component — package with sensors
 #
-# Includes the component AND pre-wires the binary_sensor, text_sensor, and
+# Standalone package — includes the component AND pre-wires the binary_sensor, text_sensor, and
 # button platforms. Requires your config to define:
-#   - id: my_ancs       on the ancs: block
-#   - api: or mqtt:     to surface sensors in Home Assistant
+#   - substitutions.friendly_name  — used as entity name prefix in Home Assistant
+#   - api: or mqtt:                — to surface sensors in Home Assistant
 #
 # Usage:
 #   packages:
-#     ancs_component: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
+#     ancs_sensors: github://wonderslug/esphome-ancs/packages/ancs-with-sensors.yaml@master
 #
-# Then add your ancs: block:
-#   ancs:
-#     id: my_ancs
-#     name: "My ANCS"
-#     on_notification_added:
-#       ...
+# Override the BLE pairing name (shown in nRF Connect when pairing):
+#   substitutions:
+#     friendly_name: "Living Room"
+#     ancs_name: "Living Room ANCS"   # optional, defaults to "ANCS HA Bridge"
+
+substitutions:
+  ancs_name: "ANCS HA Bridge"
 
 external_components:
   - source:
@@ -22,6 +23,10 @@ external_components:
       url: https://github.com/wonderslug/esphome-ancs
       ref: master
     components: [ancs]
+
+ancs:
+  id: my_ancs
+  name: "${ancs_name}"
 
 binary_sensor:
   - platform: ancs

--- a/packages/ancs-with-sensors.yaml
+++ b/packages/ancs-with-sensors.yaml
@@ -13,15 +13,20 @@
 #   substitutions:
 #     friendly_name: "Living Room"
 #     ancs_name: "Living Room ANCS"   # optional, defaults to "ANCS HA Bridge"
+#
+# Override the component ref (useful for development or feature branches):
+#   substitutions:
+#     ancs_ref: "feat/my-branch"
 
 substitutions:
   ancs_name: "ANCS HA Bridge"
+  ancs_ref: "master"
 
 external_components:
   - source:
       type: git
       url: https://github.com/wonderslug/esphome-ancs
-      ref: master
+      ref: "${ancs_ref}"
     components: [ancs]
 
 ancs:

--- a/packages/ancs.yaml
+++ b/packages/ancs.yaml
@@ -10,10 +10,17 @@
 # Pin to a release tag for production (recommended):
 #   packages:
 #     ancs_component: github://wonderslug/esphome-ancs/packages/ancs.yaml@v1.0.0
+#
+# Override the component ref (useful for development or feature branches):
+#   substitutions:
+#     ancs_ref: "feat/my-branch"
+
+substitutions:
+  ancs_ref: "master"
 
 external_components:
   - source:
       type: git
       url: https://github.com/wonderslug/esphome-ancs
-      ref: master
+      ref: "${ancs_ref}"
     components: [ancs]


### PR DESCRIPTION
## Summary

- **`ancs-ha-events.yaml`** is now fully standalone — includes its own `external_components` and base `ancs:` config (`id`, `name`, `auto_fetch_attributes`, `fetch_attributes`). Users no longer need to include `ancs.yaml` or write any `ancs:` block.
- **`ancs-with-sensors.yaml`** is now fully standalone — includes its own base `ancs:` block. Users no longer need to write `id: my_ancs` themselves.
- Both packages expose an `ancs_name` substitution (default: `"ANCS HA Bridge"`) to override the BLE pairing name.
- **`ancs.yaml`** unchanged — still the minimal component-only package for custom builders.
- **`examples/ha-events.yaml`** simplified to a single package include — no manual `external_components` or `ancs:` block.
- **New `docs/quickstart.md`** — end-to-end guide from zero to first HA automation in under 10 minutes.
- **README** reordered so the HA events path leads, with a quickstart link at the top of the installation section.
- **`docs/packages.md`** updated throughout — requirements tables, minimal configs, and combining section all reflect the new standalone reality.
- **All pairing guides** (README, quickstart, pairing.md) updated to include the "Allow to Receive Your iPhone Notifications?" dialog step that appears after the Bluetooth pair prompt.
- **Bug fix:** `connected_device` entity name corrected from "Connected Device" to "Connected iPhone" in packages.md.

## Test plan

- [x] Verify `ancs-ha-events.yaml` compiles as a standalone package (no manual `ancs:` block needed)
- [x] Verify `ancs-with-sensors.yaml` compiles as a standalone package
- [x] Confirm both packages can be combined without conflicts
- [x] Verify `examples/ha-events.yaml` contains no manual `ancs:` block
- [x] Confirm `docs/quickstart.md` renders correctly on GitHub and all links resolve
- [x] Confirm README installation section leads with HA events and quickstart link is visible
- [x] CI compile passes