### PR TITLE
feat: add notification timestamp (ANCS Date attribute, ISO 8601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ All triggers are defined inside the `ancs:` hub block.
 | `on_connect` | `device_name` (std::string) | Fires when an iPhone establishes an encrypted ANCS connection. `device_name` is the BLE display name of the phone. |
 | `on_disconnect` | `device_name` (std::string) | Fires when the connection drops. |
 | `on_notification_added` | `uid` (uint32), `category` (std::string), `category_count` (uint8), `flags` (uint8), `device_name` (std::string) | Fires immediately when a notification appears — before attribute text is fetched. Use this to react fast (e.g., start blinking on `category == "incoming_call"`). |
-| `on_notification_attributes` | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name`, `date` (all std::string) | Fires after a GATT round-trip once the requested attribute text has arrived. `date` is the iOS-assigned timestamp in `YYYYMMDD'T'HHmmSS` format (empty if `date` is not in `fetch_attributes`). |
+| `on_notification_attributes` | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name`, `date` (all std::string) | Fires after a GATT round-trip once the requested attribute text has arrived. `date` is the iOS-assigned timestamp in ISO 8601 format `YYYY-MM-DDTHH:MM:SS` (no timezone — ANCS provides local device time; empty if `date` is not in `fetch_attributes`). |
 | `on_notification_removed` | `uid` (uint32), `category` (std::string), `device_name` (std::string) | Fires when the notification is dismissed or acknowledged on the iPhone. |
 | `on_notification_modified` | `uid` (uint32), `category` (std::string), `flags` (uint8), `device_name` (std::string) | Fires when an existing notification is updated (e.g., call accepted on another device). |
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The hub block configures the BLE ANCS peripheral.  Add one block at the top leve
 | `id` | ID | _(required)_ | ESPHome component ID; used to reference the hub from sensors and actions. |
 | `name` | string | `"ESPHome-ANCS"` | BLE advertised name shown when pairing on iOS. |
 | `auto_fetch_attributes` | bool | `true` | Automatically issue an ANCS Get Notification Attributes request after each `on_notification_added` event. |
-| `fetch_attributes` | list | `[app_id, title, message]` | Which attributes to retrieve. Subset of `[app_id, title, subtitle, message]`. |
+| `fetch_attributes` | list | `[app_id, title, message]` | Which attributes to retrieve. Subset of `[app_id, title, subtitle, message, date]`. |
 | `manufacturer` | string | _(optional)_ | BLE Device Information Service manufacturer string. |
 | `model` | string | _(optional)_ | BLE Device Information Service model string. |
 | `max_connections` | int (1–7) | `3` | Maximum number of iPhones that can be simultaneously connected and bonded. Drives both the runtime connection slot count and the NVS bond storage. All paired iPhones auto-reconnect without re-pairing. |
@@ -208,7 +208,7 @@ All triggers are defined inside the `ancs:` hub block.
 | `on_connect` | `device_name` (std::string) | Fires when an iPhone establishes an encrypted ANCS connection. `device_name` is the BLE display name of the phone. |
 | `on_disconnect` | `device_name` (std::string) | Fires when the connection drops. |
 | `on_notification_added` | `uid` (uint32), `category` (std::string), `category_count` (uint8), `flags` (uint8), `device_name` (std::string) | Fires immediately when a notification appears — before attribute text is fetched. Use this to react fast (e.g., start blinking on `category == "incoming_call"`). |
-| `on_notification_attributes` | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name` (all std::string) | Fires after a GATT round-trip once the requested attribute text has arrived. Use this to display caller name, message body, etc. |
+| `on_notification_attributes` | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name`, `date` (all std::string) | Fires after a GATT round-trip once the requested attribute text has arrived. `date` is the iOS-assigned timestamp in `YYYYMMDD'T'HHmmSS` format (empty if `date` is not in `fetch_attributes`). |
 | `on_notification_removed` | `uid` (uint32), `category` (std::string), `device_name` (std::string) | Fires when the notification is dismissed or acknowledged on the iPhone. |
 | `on_notification_modified` | `uid` (uint32), `category` (std::string), `flags` (uint8), `device_name` (std::string) | Fires when an existing notification is updated (e.g., call accepted on another device). |
 

--- a/components/ancs/__init__.py
+++ b/components/ancs/__init__.py
@@ -20,6 +20,7 @@ _FETCH_MAP = {
     "title": AttributeId.TITLE,
     "subtitle": AttributeId.SUBTITLE,
     "message": AttributeId.MESSAGE,
+    "date": AttributeId.DATE,
 }
 
 ConnectTrigger = ancs_ns.class_("ConnectTrigger", automation.Trigger.template())
@@ -47,7 +48,7 @@ CONF_MANUFACTURER = "manufacturer"
 CONF_MODEL = "model"
 CONF_NIMBLE_HOST_TASK_STACK_SIZE = "nimble_host_task_stack_size"
 
-FETCH_ATTRIBUTE_OPTIONS = ["app_id", "title", "subtitle", "message"]
+FETCH_ATTRIBUTE_OPTIONS = ["app_id", "title", "subtitle", "message", "date"]
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -166,6 +167,7 @@ async def to_code(config):
                 (cg.std_string, "subtitle"),
                 (cg.std_string, "message"),
                 (cg.std_string, "device_name"),
+                (cg.std_string, "date"),
             ],
             conf,
         )

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -664,6 +664,29 @@ static void handle_notification_source(const uint8_t *buf, uint16_t len, ConnSta
 }
 
 // ---------------------------------------------------------------------------
+// Convert raw ANCS date "YYYYMMDD'T'HHmmSS" → ISO 8601 "YYYY-MM-DDTHH:MM:SS".
+// Returns the input unchanged if the 15-byte format is not recognised.
+// ---------------------------------------------------------------------------
+static std::string ancs_date_to_iso8601(const std::string &raw) {
+  if (raw.size() != 15 || raw[8] != 'T')
+    return raw;
+  std::string out;
+  out.reserve(19);
+  out.append(raw, 0, 4);   // YYYY
+  out += '-';
+  out.append(raw, 4, 2);   // MM
+  out += '-';
+  out.append(raw, 6, 2);   // DD
+  out += 'T';
+  out.append(raw, 9, 2);   // HH
+  out += ':';
+  out.append(raw, 11, 2);  // mm
+  out += ':';
+  out.append(raw, 13, 2);  // SS
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Data Source handler
 // ---------------------------------------------------------------------------
 static void handle_data_source(const uint8_t *buf, uint16_t len, ConnState *slot) {
@@ -683,7 +706,7 @@ static void handle_data_source(const uint8_t *buf, uint16_t len, ConnState *slot
       ev.title = slot->assembler.value(protocol::AttributeId::TITLE);
       ev.subtitle = slot->assembler.value(protocol::AttributeId::SUBTITLE);
       ev.message = slot->assembler.value(protocol::AttributeId::MESSAGE);
-      ev.date = slot->assembler.value(protocol::AttributeId::DATE);
+      ev.date = ancs_date_to_iso8601(slot->assembler.value(protocol::AttributeId::DATE));
       ev.device_name = slot->peer_name_buf;
       push_event(ev);
       break;

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -683,6 +683,7 @@ static void handle_data_source(const uint8_t *buf, uint16_t len, ConnState *slot
       ev.title = slot->assembler.value(protocol::AttributeId::TITLE);
       ev.subtitle = slot->assembler.value(protocol::AttributeId::SUBTITLE);
       ev.message = slot->assembler.value(protocol::AttributeId::MESSAGE);
+      ev.date = slot->assembler.value(protocol::AttributeId::DATE);
       ev.device_name = slot->peer_name_buf;
       push_event(ev);
       break;

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -672,13 +672,13 @@ static std::string ancs_date_to_iso8601(const std::string &raw) {
     return raw;
   std::string out;
   out.reserve(19);
-  out.append(raw, 0, 4);   // YYYY
+  out.append(raw, 0, 4);  // YYYY
   out += '-';
-  out.append(raw, 4, 2);   // MM
+  out.append(raw, 4, 2);  // MM
   out += '-';
-  out.append(raw, 6, 2);   // DD
+  out.append(raw, 6, 2);  // DD
   out += 'T';
-  out.append(raw, 9, 2);   // HH
+  out.append(raw, 9, 2);  // HH
   out += ':';
   out.append(raw, 11, 2);  // mm
   out += ':';

--- a/components/ancs/ancs_ble.h
+++ b/components/ancs/ancs_ble.h
@@ -24,6 +24,7 @@ struct BleEvent {
   std::string title;
   std::string subtitle;
   std::string message;
+  std::string date;  // ISO 8601-style: "YYYYMMDD'T'HHmmSS" (empty if not requested)
   // Populated only on CONNECTED: the iPhone's own name from the GAP
   // Device Name characteristic (0x2A00), e.g. "Brian's iPhone".
   std::string device_name;

--- a/components/ancs/ancs_ble.h
+++ b/components/ancs/ancs_ble.h
@@ -24,7 +24,7 @@ struct BleEvent {
   std::string title;
   std::string subtitle;
   std::string message;
-  std::string date;  // ISO 8601-style: "YYYYMMDD'T'HHmmSS" (empty if not requested)
+  std::string date;  // ISO 8601: "YYYY-MM-DDTHH:MM:SS" (empty if not requested)
   // Populated only on CONNECTED: the iPhone's own name from the GAP
   // Device Name characteristic (0x2A00), e.g. "Brian's iPhone".
   std::string device_name;

--- a/components/ancs/ancs_component.cpp
+++ b/components/ancs/ancs_component.cpp
@@ -96,6 +96,12 @@ void AncsComponent::loop() {
         break;
 
       case BleEventType::ATTRIBUTES:
+        if (ev.date.empty()) {
+          ESP_LOGI(TAG, "Attributes uid=%u app=%s title=%s", ev.uid, ev.app_id.c_str(), ev.title.c_str());
+        } else {
+          ESP_LOGI(TAG, "Attributes uid=%u app=%s title=%s date=%s", ev.uid, ev.app_id.c_str(), ev.title.c_str(),
+                   ev.date.c_str());
+        }
 #ifdef USE_TEXT_SENSOR
         if (last_title_ts_)
           last_title_ts_->publish_state(ev.title);
@@ -106,7 +112,7 @@ void AncsComponent::loop() {
         if (last_caller_ts_ && ev.category == protocol::Category::INCOMING_CALL)
           last_caller_ts_->publish_state(ev.title);
 #endif
-        on_attributes_.call(ev.uid, cat, ev.app_id, ev.title, ev.subtitle, ev.message, ev.device_name);
+        on_attributes_.call(ev.uid, cat, ev.app_id, ev.title, ev.subtitle, ev.message, ev.device_name, ev.date);
         break;
     }
   }

--- a/components/ancs/ancs_component.h
+++ b/components/ancs/ancs_component.h
@@ -58,7 +58,7 @@ class AncsComponent : public Component {
   }
   void add_on_attributes_callback(
       std::function<void(uint32_t, const std::string &, const std::string &, const std::string &, const std::string &,
-                         const std::string &, const std::string &)>
+                         const std::string &, const std::string &, const std::string &)>
           cb) {
     on_attributes_.add(std::move(cb));
   }
@@ -99,7 +99,7 @@ class AncsComponent : public Component {
   CallbackManager<void(uint32_t, const std::string &, uint8_t, const std::string &)> on_modified_;
   CallbackManager<void(uint32_t, const std::string &, const std::string &)> on_removed_;
   CallbackManager<void(uint32_t, const std::string &, const std::string &, const std::string &, const std::string &,
-                       const std::string &, const std::string &)>
+                       const std::string &, const std::string &, const std::string &)>
       on_attributes_;
 };
 

--- a/components/ancs/automation.h
+++ b/components/ancs/automation.h
@@ -53,15 +53,16 @@ class NotificationRemovedTrigger : public Trigger<uint32_t, std::string, std::st
   }
 };
 
-// attributes: (uid, category, app_id, title, subtitle, message, device_name)
+// attributes: (uid, category, app_id, title, subtitle, message, device_name, date)
 class NotificationAttributesTrigger
-    : public Trigger<uint32_t, std::string, std::string, std::string, std::string, std::string, std::string> {
+    : public Trigger<uint32_t, std::string, std::string, std::string, std::string, std::string, std::string,
+                     std::string> {
  public:
   explicit NotificationAttributesTrigger(AncsComponent *parent) {
     parent->add_on_attributes_callback(
         [this](uint32_t uid, const std::string &cat, const std::string &app, const std::string &title,
-               const std::string &sub, const std::string &msg,
-               const std::string &device_name) { this->trigger(uid, cat, app, title, sub, msg, device_name); });
+               const std::string &sub, const std::string &msg, const std::string &device_name,
+               const std::string &date) { this->trigger(uid, cat, app, title, sub, msg, device_name, date); });
   }
 };
 

--- a/components/ancs/automation.h
+++ b/components/ancs/automation.h
@@ -54,9 +54,8 @@ class NotificationRemovedTrigger : public Trigger<uint32_t, std::string, std::st
 };
 
 // attributes: (uid, category, app_id, title, subtitle, message, device_name, date)
-class NotificationAttributesTrigger
-    : public Trigger<uint32_t, std::string, std::string, std::string, std::string, std::string, std::string,
-                     std::string> {
+class NotificationAttributesTrigger : public Trigger<uint32_t, std::string, std::string, std::string, std::string,
+                                                     std::string, std::string, std::string> {
  public:
   explicit NotificationAttributesTrigger(AncsComponent *parent) {
     parent->add_on_attributes_callback(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,7 +343,7 @@ while (ble_.pop_event(ev)):
                         fire on_removed_(uid, category_string, device_name)
         NOTIF_MODIFIED → fire on_modified_(uid, category_string, flags, device_name)
         ATTRIBUTES    → publish last_title_ts_, last_message_ts_, etc.
-                        fire on_attributes_(uid, cat, app_id, title, subtitle, message, device_name)
+                        fire on_attributes_(uid, cat, app_id, title, subtitle, message, device_name, date)
 ```
 
 All triggers receive `device_name` (std::string) as their last variable, identifying

--- a/docs/categories/README.md
+++ b/docs/categories/README.md
@@ -45,7 +45,7 @@ Requires `auto_fetch_attributes: true` and the relevant key in `fetch_attributes
 | `title` | `std::string` | Sender name, event title, email subject, etc. |
 | `subtitle` | `std::string` | Thread name, sender detail, etc. |
 | `message` | `std::string` | Notification body — empty if iOS previews are off |
-| `date` | `std::string` | iOS-assigned timestamp in `YYYYMMDD'T'HHmmSS` format — empty if `date` is not in `fetch_attributes` |
+| `date` | `std::string` | iOS-assigned timestamp in ISO 8601 format `YYYY-MM-DDTHH:MM:SS` (no timezone — ANCS provides local device time) — empty if `date` is not in `fetch_attributes` |
 | `device_name` | `std::string` | BLE display name of the connected iPhone |
 
 ### Event flags

--- a/docs/categories/README.md
+++ b/docs/categories/README.md
@@ -45,6 +45,8 @@ Requires `auto_fetch_attributes: true` and the relevant key in `fetch_attributes
 | `title` | `std::string` | Sender name, event title, email subject, etc. |
 | `subtitle` | `std::string` | Thread name, sender detail, etc. |
 | `message` | `std::string` | Notification body — empty if iOS previews are off |
+| `date` | `std::string` | iOS-assigned timestamp in `YYYYMMDD'T'HHmmSS` format — empty if `date` is not in `fetch_attributes` |
+| `device_name` | `std::string` | BLE display name of the connected iPhone |
 
 ### Event flags
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -155,8 +155,8 @@ three HA events over the ESPHome native API:
 
 | Event | When it fires | Payload fields |
 |---|---|---|
-| `esphome.ancs_incoming_call` | An incoming call notification has its attributes available | `uid`, `caller`, `app_id`, `device_name`, `iphone_name` |
-| `esphome.ancs_notification` | Any non-call notification has its attributes available | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `device_name`, `iphone_name` |
+| `esphome.ancs_incoming_call` | An incoming call notification has its attributes available | `uid`, `caller`, `app_id`, `date`, `device_name`, `iphone_name` |
+| `esphome.ancs_notification` | Any non-call notification has its attributes available | `uid`, `category`, `app_id`, `title`, `subtitle`, `message`, `date`, `device_name`, `iphone_name` |
 | `esphome.ancs_call_ended` | An incoming call is declined or answered | `uid`, `device_name`, `iphone_name` |
 
 ### When to use it
@@ -216,6 +216,17 @@ will always be non-empty in practice.
 
 If you have more than one ANCS device paired, `iphone_name` identifies which phone
 sent the notification (while `device_name` identifies which ESP32 fired the event).
+
+### `date` field
+
+`date` contains the timestamp iOS assigned to the notification, in `YYYYMMDD'T'HHmmSS` format
+(e.g. `20260604T143022`). This reflects when the notification was *generated* on the iOS side,
+not when it was delivered over BLE — so notifications queued while the phone was out of range
+will carry their original creation time once they sync.
+
+The field is present in both `esphome.ancs_incoming_call` and `esphome.ancs_notification` events.
+It is an empty string only if the ANCS Date attribute was not included in `fetch_attributes`,
+which is not the case for this package (it fetches `date` by default).
 
 ### `uid` field
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -219,8 +219,9 @@ sent the notification (while `device_name` identifies which ESP32 fired the even
 
 ### `date` field
 
-`date` contains the timestamp iOS assigned to the notification, in `YYYYMMDD'T'HHmmSS` format
-(e.g. `20260604T143022`). This reflects when the notification was *generated* on the iOS side,
+`date` contains the timestamp iOS assigned to the notification, in ISO 8601 format
+`YYYY-MM-DDTHH:MM:SS` (e.g. `2026-06-04T14:30:22`). ANCS provides local device time without
+a timezone offset. This reflects when the notification was *generated* on the iOS side,
 not when it was delivered over BLE — so notifications queued while the phone was out of range
 will carry their original creation time once they sync.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,8 +106,8 @@ Three events are available:
 
 | Event | When | Key payload fields |
 |---|---|---|
-| `esphome.ancs_incoming_call` | Incoming call arrives | `caller`, `app_id`, `iphone_name`, `device_name` |
-| `esphome.ancs_notification` | Any other notification | `category`, `title`, `message`, `app_id`, `iphone_name`, `device_name` |
+| `esphome.ancs_incoming_call` | Incoming call arrives | `caller`, `app_id`, `date`, `iphone_name`, `device_name` |
+| `esphome.ancs_notification` | Any other notification | `category`, `title`, `message`, `app_id`, `date`, `iphone_name`, `device_name` |
 | `esphome.ancs_call_ended` | Call answered or declined | `uid`, `iphone_name`, `device_name` |
 
 See [docs/packages.md](packages.md) for all payload fields, more automation examples (TTS, filtering by app ID, filtering by category), and how to add HA entity sensors alongside events.

--- a/examples/log-everything.yaml
+++ b/examples/log-everything.yaml
@@ -36,7 +36,7 @@ ancs:
 
   # Fetch the full attribute set so on_notification_attributes can log them all.
   auto_fetch_attributes: true
-  fetch_attributes: [app_id, title, subtitle, message]
+  fetch_attributes: [app_id, title, subtitle, message, date]
 
   on_connect:
     - logger.log:
@@ -72,7 +72,7 @@ ancs:
   # Fires after the GATT roundtrip, once the requested text has arrived.
   on_notification_attributes:
     - logger.log:
-        format: "ATTRS     uid=%u  dev=%-16s  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s"
+        format: "ATTRS     uid=%u  dev=%-16s  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s  date=%s"
         tag: "ancs.demo"
         args:
           - uid
@@ -82,6 +82,7 @@ ancs:
           - title.c_str()
           - subtitle.c_str()
           - message.c_str()
+          - date.c_str()
 
   # Fires when an existing notification is updated (e.g. call accepted elsewhere).
   on_notification_modified:

--- a/packages/ancs-ha-events.yaml
+++ b/packages/ancs-ha-events.yaml
@@ -2,9 +2,9 @@
 #
 # Fires three HA events when iPhone notifications arrive via ANCS:
 #
-#   esphome.ancs_incoming_call  — incoming call; payload: uid, caller, app_id, device_name, iphone_name
+#   esphome.ancs_incoming_call  — incoming call; payload: uid, caller, app_id, date, device_name, iphone_name
 #   esphome.ancs_notification   — all other categories; payload: uid, category, app_id,
-#                                 title, subtitle, message, device_name, iphone_name
+#                                 title, subtitle, message, date, device_name, iphone_name
 #   esphome.ancs_call_ended     — call declined or answered; payload: uid, device_name, iphone_name
 #
 # Standalone package — no other packages required. Include it and add your connectivity config.
@@ -47,10 +47,10 @@ ancs:
   id: my_ancs
   name: "${ancs_name}"
   auto_fetch_attributes: true
-  fetch_attributes: [app_id, title, subtitle, message]
+  fetch_attributes: [app_id, title, subtitle, message, date]
   on_notification_attributes:
     - logger.log:
-        format: "ATTRS     uid=%u  dev=%-16s  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s"
+        format: "ATTRS     uid=%u  dev=%-16s  cat=%-16s  app=%s  title=%s  sub=%s  msg=%s  date=%s"
         tag: "ancs.notification_attrs"
         args:
           - uid
@@ -60,6 +60,7 @@ ancs:
           - title.c_str()
           - subtitle.c_str()
           - message.c_str()
+          - date.c_str()
     - if:
         condition:
           lambda: 'return category == "incoming_call";'
@@ -70,6 +71,7 @@ ancs:
                 uid: !lambda 'return std::to_string(uid);'
                 caller: !lambda 'return title;'
                 app_id: !lambda 'return app_id;'
+                date: !lambda 'return date;'
                 device_name: !lambda 'return std::string(App.get_name());'
                 iphone_name: !lambda 'return device_name;'
         else:
@@ -82,6 +84,7 @@ ancs:
                 title: !lambda 'return title;'
                 subtitle: !lambda 'return subtitle;'
                 message: !lambda 'return message;'
+                date: !lambda 'return date;'
                 device_name: !lambda 'return std::string(App.get_name());'
                 iphone_name: !lambda 'return device_name;'
 


### PR DESCRIPTION
Closes #11

## Summary

- Fetches the ANCS `Date` attribute (attribute ID `0x05`) alongside title, message, etc.
- Converts the raw iOS format (`YYYYMMDD'T'HHmmSS`) to ISO 8601 (`YYYY-MM-DDTHH:MM:SS`) before surfacing it — ANCS provides local device time with no timezone offset
- Exposes `date` as the last variable in `on_notification_attributes` (after `device_name`, non-breaking for existing positional lambdas)
- Adds `date` to the `ancs-ha-events.yaml` package fetch list and both HA event payloads (`esphome.ancs_incoming_call`, `esphome.ancs_notification`)
- Logs timestamp alongside title/app in the component's `ATTRIBUTES` event handler

## Breaking changes

None. `date` is appended as the final variable to `on_notification_attributes`. Existing automations that don't reference it are unaffected.

## New config

Add `date` to `fetch_attributes` to opt in:

```yaml
ancs:
  fetch_attributes: [app_id, title, message, date]
  on_notification_attributes:
    - logger.log:
        format: "title=%s  date=%s"
        args: [title.c_str(), date.c_str()]
```

The `ancs-ha-events.yaml` package fetches `date` by default — no config change needed for HA event users.

## Test plan

- [x] Flash `feature/notification-timestamp` branch
- [x] Pair iPhone and trigger a notification
- [x] Confirm `date` appears in `on_notification_attributes` log in `YYYY-MM-DDTHH:MM:SS` format
- [x] Confirm `date` field present in `esphome.ancs_notification` HA event payload
- [x] Confirm existing automations without `date` still compile and fire correctly
- [x] Confirm `date` is empty string when not included in `fetch_attributes`