### PR TITLE
fix: resolve BLE reconnect failures after power cycle

### DIFF
--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -465,7 +465,7 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg) {
       uint16_t enc_handle = event->enc_change.conn_handle;
       ConnState *slot = find_slot(enc_handle);
       if (!slot) {
-        ESP_LOGW(TAG, "enc_change for unknown handle=%u — ignoring", enc_handle);
+        ESP_LOGD(TAG, "enc_change for unknown handle=%u — ignoring", enc_handle);
         return 0;
       }
       if (event->enc_change.status == 0) {

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -403,8 +403,25 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg) {
           ble_gap_terminate(event->connect.conn_handle, 0x13);
           return 0;
         }
-        ESP_LOGI(TAG, "connected handle=%u — initiating security", slot->conn_handle);
-        ble_gap_security_initiate(slot->conn_handle);
+        // For bonded peers iOS automatically starts LL encryption on reconnect.
+        // Sending a Security Request while LL_START_ENC is already in flight
+        // makes iOS respond with SMP Pairing Failed (0x0D), causing the
+        // enc_change status=13 retry storm after power cycle. Only send the
+        // Security Request for new (unbonded) peers to trigger the pairing dialog.
+        struct ble_gap_conn_desc connect_desc;
+        bool already_bonded = false;
+        if (ble_gap_conn_find(slot->conn_handle, &connect_desc) == 0) {
+          struct ble_store_key_sec bond_key = {};
+          bond_key.peer_addr = connect_desc.peer_id_addr;
+          struct ble_store_value_sec bond_val;
+          already_bonded = (ble_store_read_peer_sec(&bond_key, &bond_val) == 0);
+        }
+        if (already_bonded) {
+          ESP_LOGI(TAG, "connected handle=%u — bonded peer, waiting for LTK encryption", slot->conn_handle);
+        } else {
+          ESP_LOGI(TAG, "connected handle=%u — new peer, requesting pairing", slot->conn_handle);
+          ble_gap_security_initiate(slot->conn_handle);
+        }
         if (count_active_slots() < CONFIG_BT_NIMBLE_MAX_CONNECTIONS)
           start_advertising();
       } else {

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -417,7 +417,19 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg) {
           already_bonded = (ble_store_read_peer_sec(&bond_key, &bond_val) == 0);
         }
         if (already_bonded) {
-          ESP_LOGI(TAG, "connected handle=%u — bonded peer, waiting for LTK encryption", slot->conn_handle);
+          if (connect_desc.sec_state.encrypted) {
+            // NimBLE dispatched ENC_CHANGE before CONNECT (iOS fast-reconnect
+            // quirk). The slot didn't exist yet so it was ignored. Start
+            // discovery now instead of waiting for an enc_change that won't come.
+            ESP_LOGI(TAG, "connected handle=%u — already encrypted, starting ANCS discovery", slot->conn_handle);
+            int rc = ble_gattc_disc_all_svcs(slot->conn_handle, on_disc_svc, NULL);
+            if (rc != 0) {
+              ESP_LOGE(TAG, "ble_gattc_disc_all_svcs failed rc=%d — terminating", rc);
+              ble_gap_terminate(slot->conn_handle, 0x13);
+            }
+          } else {
+            ESP_LOGI(TAG, "connected handle=%u — bonded peer, waiting for LTK encryption", slot->conn_handle);
+          }
         } else {
           ESP_LOGI(TAG, "connected handle=%u — new peer, requesting pairing", slot->conn_handle);
           ble_gap_security_initiate(slot->conn_handle);


### PR DESCRIPTION
Fixes #15

## Root causes

Two separate NimBLE/iOS timing issues combined to prevent reliable reconnection after a power cycle.

### 1. Security Request collides with in-flight LL encryption (enc_change storm)

For already-bonded iPhones, iOS immediately starts LL_START_ENCRYPTION using the stored LTK the moment it sees the device advertising. The code unconditionally called `ble_gap_security_initiate()` in the CONNECT handler, sending an SMP Security Request while the LL encryption handshake was already in flight. iOS responded with SMP Pairing Failed (0x0D — "pairing operation already in progress"), which NimBLE surfaced as `enc_change status=13`. The terminate → reconnect → repeat loop ran indefinitely.

**Fix:** Check the NimBLE bond store at connect time. If a bond exists for the peer's identity address, skip `ble_gap_security_initiate()` — iOS handles LL encryption automatically. For new/unbonded peers the Security Request is still sent to trigger the iOS pairing dialog.

### 2. ENC_CHANGE fires before CONNECT (silent dead connection)

On iOS fast reconnect, NimBLE can dispatch `BLE_GAP_EVENT_ENC_CHANGE` before `BLE_GAP_EVENT_CONNECT` for the same handle. The enc_change fired while no slot existed yet, was ignored, then the slot was allocated and waited forever for an enc_change that already passed — leaving the phone showing as connected with no notifications flowing.

**Fix:** At CONNECT time, after allocating the slot, check `desc.sec_state.encrypted`. If the connection is already encrypted, skip waiting and start GATT service discovery immediately.

### 3. Log noise

The "enc_change for unknown handle — ignoring" message that fires on almost every fast reconnect was a WARN, making it appear as an error in normal logs. Downgraded to DEBUG since it is now expected behavior handled by fix #2.

## Test results

Verified across three boot types with a bonded iPhone:
- **OTA reboot** — hits fast-reconnect path (`already encrypted, starting ANCS discovery`) ✓
- **Power cycle** — hits normal path (`bonded peer, waiting for LTK encryption` → `encrypted`) ✓
- **Manual reconnect** — works as before ✓

Notifications flowing in all cases.