### PR TITLE
fix: remove redundant per-characteristic debug logs that corrupt VERBOSE output

### DIFF
--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -602,15 +602,17 @@ static int on_disc_chr(uint16_t conn_handle, const struct ble_gatt_error *error,
     return 0;
   }
 
+  // Per-characteristic handles are logged together by the "ANCS chars done"
+  // summary once discovery completes (BLE_HS_EDONE above). Logging each one
+  // individually here fires three back-to-back ESP_LOGD calls from the
+  // nimble_host task during the discovery burst, which interleaves with the
+  // main-loop logger on the UART and corrupts the serial stream at VERBOSE.
   if (ble_uuid_cmp(&chr->uuid.u, u128p(&s_notif_src_uuid)) == 0) {
     slot->ns_handle = chr->val_handle;
-    ESP_LOGD(TAG, "NotifSrc val_handle=%u", slot->ns_handle);
   } else if (ble_uuid_cmp(&chr->uuid.u, u128p(&s_ctrl_point_uuid)) == 0) {
     slot->cp_handle = chr->val_handle;
-    ESP_LOGD(TAG, "CtrlPoint val_handle=%u", slot->cp_handle);
   } else if (ble_uuid_cmp(&chr->uuid.u, u128p(&s_data_src_uuid)) == 0) {
     slot->ds_handle = chr->val_handle;
-    ESP_LOGD(TAG, "DataSrc val_handle=%u", slot->ds_handle);
   }
   return 0;
 }


### PR DESCRIPTION
## Summary

Fixes garbled/corrupted serial output at VERBOSE log level during ANCS GATT characteristic discovery (walls of repeated `c val_handle=43` fragments, ANSI codes bleeding mid-line).

## Root cause

`on_disc_chr()` emitted three back-to-back `ESP_LOGD` lines (`NotifSrc`/`CtrlPoint`/`DataSrc`) from the `nimble_host` FreeRTOS task. During a discovery burst (e.g. an iPhone drifting in/out of BLE range), these rapid debug writes interleave with the main-loop logger on the same UART and corrupt the stream.

## Change

Removed the three redundant per-characteristic `ESP_LOGD` calls, keeping the handle assignments. All three handles are already reported together in one atomic line once discovery completes:

```
[I][ancs.ble]: ANCS chars done: ns=40 cp=37 ds=43
```

So there is **zero information loss**, and the back-to-back-debug burst that triggered the corruption is gone.

## Testing

- Not compiled/flashed (straight removal of log statements; assignments preserved and still consumed by the summary line).
- Original corruption reproduced organically via a real iPhone going out of BLE range and brushing back in.

Closes #17