### PR TITLE
ci: notify ANCService on release to trigger firmware rebuild

### DIFF
--- a/.github/workflows/notify-ancservice.yml
+++ b/.github/workflows/notify-ancservice.yml
@@ -1,0 +1,16 @@
+name: Notify ANCService
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ANCService rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ANCSERVICE_DISPATCH_TOKEN }}
+          repository: wonderslug/ANCService
+          event-type: component-release
+          client-payload: '{"tag": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
Adds a workflow that fires a \`repository_dispatch\` (\`component-release\`) to \`wonderslug/ANCService\` whenever a release is **published** here, so ANCService automatically rebuilds its pre-compiled firmware against the new component version.

- New workflow: \`.github/workflows/notify-ancservice.yml\` (on \`release: published\`).
- Payload carries the release \`tag\`; the ANCService receiver re-pins \`ancs_ref\`, patch-bumps, and re-tags.

## Requires before it works
Secret \`ANCSERVICE_DISPATCH_TOKEN\` in this repo: a fine-grained PAT with \`contents: write\` on \`wonderslug/ANCService\`.