### PR TITLE
Configurable BLE advertised name (node-name default + runtime name_suffix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ text_sensor:
       name: "Last App ID"
     last_caller:
       name: "Last Caller"
+    advertised_name:
+      name: "Advertised Name"
 ```
 
 | Sensor key | Description |
@@ -304,6 +306,7 @@ text_sensor:
 | `last_message` | Message body of the most recently received notification. |
 | `last_app_id` | Bundle ID of the source app (e.g., `com.apple.mobilephone`). |
 | `last_caller` | Caller name from the most recent incoming-call notification. |
+| `advertised_name` | The current resolved BLE advertised name (diagnostic, read-only) — see [BLE advertised name](#ble-advertised-name). Updates live when the name suffix changes. |
 
 ### `text` platform `ancs`
 

--- a/README.md
+++ b/README.md
@@ -191,13 +191,56 @@ The hub block configures the BLE ANCS peripheral.  Add one block at the top leve
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `id` | ID | _(required)_ | ESPHome component ID; used to reference the hub from sensors and actions. |
-| `name` | string | `"ESPHome-ANCS"` | BLE advertised name shown when pairing on iOS. |
+| `name` | string | _(optional)_ | Overrides the BLE advertised name shown when pairing on iOS (max 29 chars). When omitted, the ESPHome node name is used — see [BLE advertised name](#ble-advertised-name). |
 | `auto_fetch_attributes` | bool | `true` | Automatically issue an ANCS Get Notification Attributes request after each `on_notification_added` event. |
 | `fetch_attributes` | list | `[app_id, title, message]` | Which attributes to retrieve. Subset of `[app_id, title, subtitle, message, date]`. |
 | `manufacturer` | string | _(optional)_ | BLE Device Information Service manufacturer string. |
 | `model` | string | _(optional)_ | BLE Device Information Service model string. |
 | `max_connections` | int (1–7) | `3` | Maximum number of iPhones that can be simultaneously connected and bonded. Drives both the runtime connection slot count and the NVS bond storage. All paired iPhones auto-reconnect without re-pairing. |
 | `nimble_host_task_stack_size` | int (4096–32768) | `8192` | Stack size (bytes) for the NimBLE host task. The ESP-IDF default of 4096 overflows during LE Secure Connections pairing and reboots the device (`stack overflow in task nimble_host`); leave at the default unless a custom build still overflows. |
+
+### BLE advertised name
+
+The name shown in a BLE scanner (e.g. nRF Connect) and reported as the GAP device
+name is resolved at runtime:
+
+- **Default:** the ESPHome node name (`esphome: name:`). Setting
+  `esphome: name_add_mac_suffix: true` makes it unique per device
+  (`yournode-a1b2c3`) — recommended for pre-compiled firmware shipped to many
+  devices, since uniqueness is available before Home Assistant for first pairing.
+- **`name:` on `ancs:` (optional):** overrides the base name (max 29 chars). When
+  omitted, the node name is used.
+- **`name_suffix` text entity (optional):** a friendly suffix you can set at
+  runtime from Home Assistant, MQTT, or the device's `web_server` page. When set,
+  it replaces the MAC suffix (`ancservice-a1b2c3` → `ancservice-Kitchen`) or, if
+  there is no MAC suffix, is appended (`ancservice` → `ancservice-Kitchen`). It is
+  persisted across reboots and applied live — no reboot or re-pairing required
+  (existing iOS bonds are kept; iOS keys bonds on the address, not the name).
+
+> **Upgrade note:** Previously, omitting `name:` advertised the static name
+> `ESPHome-ANCS`. It now defaults to the ESPHome node name. If you relied on the
+> old default, set `name: "ESPHome-ANCS"` explicitly on `ancs:` to keep it.
+
+```yaml
+esphome:
+  name: ancservice
+  name_add_mac_suffix: true   # -> ancservice-a1b2c3, unique per device
+
+ancs:
+  id: my_ancs
+
+# Editable from Home Assistant, MQTT, and the local web_server page:
+web_server:
+  port: 80
+
+text:
+  - platform: ancs
+    ancs_id: my_ancs
+    name: "Device Name Suffix"
+```
+
+The `web_server` UI shows the `name_suffix` entity as an editable text field, so
+the friendly name can be set directly on the device without Home Assistant.
 
 ### Triggers
 
@@ -253,6 +296,19 @@ text_sensor:
 | `last_message` | Message body of the most recently received notification. |
 | `last_app_id` | Bundle ID of the source app (e.g., `com.apple.mobilephone`). |
 | `last_caller` | Caller name from the most recent incoming-call notification. |
+
+### `text` platform `ancs`
+
+```yaml
+text:
+  - platform: ancs
+    ancs_id: my_ancs
+    name: "Device Name Suffix"
+```
+
+| Entity key | Description |
+|------------|-------------|
+| `name_suffix` | Editable friendly suffix appended to (or replacing the MAC suffix of) the BLE advertised name — see [BLE advertised name](#ble-advertised-name). Persisted to NVS and applied live without a reboot or re-pairing. |
 
 ### Actions
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ device is in range with no further use of nRF Connect required.
 1. Install **nRF Connect for Mobile** from the App Store.
 2. Flash the ESP32 and power it on. Watch the serial log for `NimBLE synced` and `advertising started`.
 3. Open nRF Connect → **SCANNER** tab → tap **SCAN**.
-4. Find your device by the BLE name shown for your device (your node name, e.g. `ancservice-a1b2c3`) and tap **CONNECT**.
+ 4. Find your device by the BLE name shown for your device (your node name, e.g. `ancservice-a1b2c3`) and tap **CONNECT**.
 5. The ESP32 receives the connection and immediately requests pairing. iOS shows a system dialog: **"ancservice-a1b2c3" Would Like to Pair With Your iPhone** → tap **Pair**.
 6. iOS shows a second dialog: **Allow "ancservice-a1b2c3" to Receive Your iPhone Notifications?** → tap **Allow**. This grants ANCS access.
 7. nRF Connect shows the GATT services being discovered. You will see the ANCS service appear (`7905F431-…`).
@@ -240,10 +240,15 @@ text:
   - platform: ancs
     ancs_id: my_ancs
     name: "Device Name Suffix"
+    entity_category: config
 ```
 
-The `web_server` UI shows the `name_suffix` entity as an editable text field, so
-the friendly name can be set directly on the device without Home Assistant.
+With `api:` enabled, this appears automatically in Home Assistant as a native
+`text` entity (an editable text field) — no template or helper needed. The
+`web_server` UI shows the same entity, so the friendly name can also be set
+directly on the device without Home Assistant. `entity_category: config` files it
+under the device's **Configuration** section rather than as a primary control;
+omit it to show it as a main control.
 
 ### Triggers
 
@@ -307,11 +312,17 @@ text:
   - platform: ancs
     ancs_id: my_ancs
     name: "Device Name Suffix"
+    entity_category: config   # optional: file under HA's Configuration section
 ```
+
+Exposed automatically as a native Home Assistant `text` entity over the ESPHome
+`api:` (read/write — editing it in HA calls `text.set_value`), and editable from
+the `web_server` UI and MQTT. No wrapping or template needed.
 
 | Entity key | Description |
 |------------|-------------|
 | `name_suffix` | Editable friendly suffix appended to (or replacing the MAC suffix of) the BLE advertised name — see [BLE advertised name](#ble-advertised-name). Persisted to NVS and applied live without a reboot or re-pairing. |
+| `entity_category` _(optional)_ | Standard ESPHome entity option; set to `config` to place the entity under the device's Configuration section in Home Assistant. |
 
 ### Actions
 

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ device is in range with no further use of nRF Connect required.
 1. Install **nRF Connect for Mobile** from the App Store.
 2. Flash the ESP32 and power it on. Watch the serial log for `NimBLE synced` and `advertising started`.
 3. Open nRF Connect → **SCANNER** tab → tap **SCAN**.
-4. Find your device by the BLE name you set (e.g. `ESPHome-ANCS`) and tap **CONNECT**.
-5. The ESP32 receives the connection and immediately requests pairing. iOS shows a system dialog: **"ESPHome-ANCS" Would Like to Pair With Your iPhone** → tap **Pair**.
-6. iOS shows a second dialog: **Allow "ESPHome-ANCS" to Receive Your iPhone Notifications?** → tap **Allow**. This grants ANCS access.
+4. Find your device by the BLE name shown for your device (your node name, e.g. `ancservice-a1b2c3`) and tap **CONNECT**.
+5. The ESP32 receives the connection and immediately requests pairing. iOS shows a system dialog: **"ancservice-a1b2c3" Would Like to Pair With Your iPhone** → tap **Pair**.
+6. iOS shows a second dialog: **Allow "ancservice-a1b2c3" to Receive Your iPhone Notifications?** → tap **Allow**. This grants ANCS access.
 7. nRF Connect shows the GATT services being discovered. You will see the ANCS service appear (`7905F431-…`).
 8. Close nRF Connect. The bond is now stored at the iOS system level.
 9. The ESP32 logs show `ANCS chars done` and `iPhone connected`. ESPHome sensors reflect the connected state.
@@ -216,6 +216,9 @@ name is resolved at runtime:
   there is no MAC suffix, is appended (`ancservice` → `ancservice-Kitchen`). It is
   persisted across reboots and applied live — no reboot or re-pairing required
   (existing iOS bonds are kept; iOS keys bonds on the address, not the name).
+  Note: if all BLE connection slots are currently in use (the device isn't
+  advertising), the GAP name updates immediately but the broadcast/scanned name
+  refreshes on the next advertising cycle, i.e. once a peer disconnects.
 
 > **Upgrade note:** Previously, omitting `name:` advertised the static name
 > `ESPHome-ANCS`. It now defaults to the ESPHome node name. If you relied on the

--- a/components/ancs/__init__.py
+++ b/components/ancs/__init__.py
@@ -53,7 +53,10 @@ FETCH_ATTRIBUTE_OPTIONS = ["app_id", "title", "subtitle", "message", "date"]
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(AncsComponent),
-        cv.Optional(CONF_NAME, default="ESPHome-ANCS"): cv.All(cv.string, cv.Length(max=29)),
+        # Base advertised name. When omitted, defaults at runtime to the ESPHome
+        # node name (App.get_name()), which already carries the per-device MAC
+        # suffix if `esphome: name_add_mac_suffix: true` is set.
+        cv.Optional(CONF_NAME): cv.All(cv.string, cv.Length(max=29)),
         cv.Optional(CONF_AUTO_FETCH_ATTRIBUTES, default=True): cv.boolean,
         cv.Optional(CONF_FETCH_ATTRIBUTES, default=["app_id", "title", "message"]): cv.ensure_list(
             cv.one_of(*FETCH_ATTRIBUTE_OPTIONS, lower=True)
@@ -115,7 +118,9 @@ FINAL_VALIDATE_SCHEMA = _validate_no_bluedroid_ble
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    cg.add(var.set_device_name(config[CONF_NAME]))
+    if CONF_NAME in config:
+        cg.add(var.set_base_name(config[CONF_NAME]))
+        cg.add(var.set_name_configured(True))
     cg.add(var.set_auto_fetch(config[CONF_AUTO_FETCH_ATTRIBUTES]))
     cg.add(var.set_manufacturer(config[CONF_MANUFACTURER]))
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/components/ancs/ancs_ble.cpp
+++ b/components/ancs/ancs_ble.cpp
@@ -994,6 +994,18 @@ void AncsBle::disconnect() {
   }
 }
 
+void AncsBle::set_advertised_name(const std::string &name) {
+  s_cfg.device_name = name;
+  int rc = ble_svc_gap_device_name_set(name.c_str());
+  if (rc != 0)
+    ESP_LOGW(TAG, "ble_svc_gap_device_name_set failed: %d", rc);
+  // Rebuild adv + scan-response data on the next loop() (the HCI set-data calls
+  // must run on the main task, not a NimBLE callback). Existing iOS bonds are
+  // unaffected — they key on the IRK/address, not the GAP device name.
+  s_adv_override_pending = true;
+  ESP_LOGI(TAG, "advertised name set to '%s'", name.c_str());
+}
+
 void AncsBle::clear_bonds_and_restart() {
   ESP_LOGI(TAG, "clearing all bonds and restarting");
   ble_store_clear();

--- a/components/ancs/ancs_ble.h
+++ b/components/ancs/ancs_ble.h
@@ -52,6 +52,8 @@ class AncsBle {
   // Actions (safe to call from the ESPHome loop task).
   void clear_bonds_and_restart();
   void disconnect();
+  // Update the advertised / GAP device name at runtime and trigger a re-advertise.
+  void set_advertised_name(const std::string &name);
   void request_attributes(uint32_t uid, const std::string &device_name = "");
 };
 

--- a/components/ancs/ancs_component.cpp
+++ b/components/ancs/ancs_component.cpp
@@ -27,6 +27,9 @@ void AncsComponent::setup() {
   if (call_active_bs_)
     call_active_bs_->publish_initial_state(false);
 #endif
+#ifdef USE_TEXT_SENSOR
+  publish_advertised_name_();
+#endif
 }
 
 void AncsComponent::loop() {
@@ -131,9 +134,20 @@ void AncsComponent::dump_config() {
 
 void AncsComponent::set_name_suffix(const std::string &suffix) {
   name_suffix_ = suffix;
-  if (ble_initialized_)
+  if (ble_initialized_) {
     ble_.set_advertised_name(resolve_name());
+#ifdef USE_TEXT_SENSOR
+    publish_advertised_name_();
+#endif
+  }
 }
+
+#ifdef USE_TEXT_SENSOR
+void AncsComponent::publish_advertised_name_() {
+  if (advertised_name_ts_)
+    advertised_name_ts_->publish_state(resolve_name());
+}
+#endif
 
 std::string AncsComponent::resolve_name() const {
   // get_mac_address() returns 12 lowercase hex chars (no separators).

--- a/components/ancs/ancs_component.cpp
+++ b/components/ancs/ancs_component.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) 2026 Brian Towles
 
 #include "ancs_component.h"
+#include "ancs_name_resolver.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -11,12 +14,13 @@ static const char *const TAG = "ancs";
 
 void AncsComponent::setup() {
   BleConfig cfg;
-  cfg.device_name = device_name_;
+  cfg.device_name = resolve_name();
   cfg.manufacturer = manufacturer_;
   cfg.model = model_;
   cfg.auto_fetch = auto_fetch_;
   cfg.fetch_attributes = fetch_attrs_;
   ble_.init(cfg);
+  ble_initialized_ = true;
 #ifdef USE_BINARY_SENSOR
   if (connected_bs_)
     connected_bs_->publish_initial_state(false);
@@ -119,9 +123,24 @@ void AncsComponent::loop() {
 }
 void AncsComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "ANCS:");
-  ESP_LOGCONFIG(TAG, "  Device name: %s", device_name_.c_str());
+  ESP_LOGCONFIG(TAG, "  Advertised name: %s", resolve_name().c_str());
+  ESP_LOGCONFIG(TAG, "  Name source: %s", name_configured_ ? "configured" : "esphome node name");
   ESP_LOGCONFIG(TAG, "  Auto fetch attributes: %s", YESNO(auto_fetch_));
   ESP_LOGCONFIG(TAG, "  Max connections: %d", CONFIG_BT_NIMBLE_MAX_CONNECTIONS);
+}
+
+void AncsComponent::set_name_suffix(const std::string &suffix) {
+  name_suffix_ = suffix;
+  if (ble_initialized_)
+    ble_.set_advertised_name(resolve_name());
+}
+
+std::string AncsComponent::resolve_name() const {
+  // get_mac_address() returns 12 lowercase hex chars (no separators).
+  std::string mac6 = get_mac_address();
+  if (mac6.size() > 6)
+    mac6 = mac6.substr(mac6.size() - 6);
+  return resolve_ble_name(base_name_, name_configured_, App.get_name(), mac6, name_suffix_);
 }
 
 }  // namespace ancs

--- a/components/ancs/ancs_component.h
+++ b/components/ancs/ancs_component.h
@@ -44,6 +44,7 @@ class AncsComponent : public Component {
   void set_last_message_text_sensor(text_sensor::TextSensor *s) { last_message_ts_ = s; }
   void set_last_app_id_text_sensor(text_sensor::TextSensor *s) { last_app_id_ts_ = s; }
   void set_last_caller_text_sensor(text_sensor::TextSensor *s) { last_caller_ts_ = s; }
+  void set_advertised_name_text_sensor(text_sensor::TextSensor *s) { advertised_name_ts_ = s; }
 #endif
 
   void add_on_connect_callback(std::function<void(const std::string &)> cb) { on_connect_.add(std::move(cb)); }
@@ -81,6 +82,10 @@ class AncsComponent : public Component {
 
   // Resolve the effective advertised name from base/node name + suffix.
   std::string resolve_name() const;
+#ifdef USE_TEXT_SENSOR
+  // Push the resolved advertised name to its diagnostic text sensor, if configured.
+  void publish_advertised_name_();
+#endif
   std::string manufacturer_{"ESPHome"};
   std::string model_{"ANCS Node"};
   bool auto_fetch_{true};
@@ -99,6 +104,7 @@ class AncsComponent : public Component {
   text_sensor::TextSensor *last_message_ts_{nullptr};
   text_sensor::TextSensor *last_app_id_ts_{nullptr};
   text_sensor::TextSensor *last_caller_ts_{nullptr};
+  text_sensor::TextSensor *advertised_name_ts_{nullptr};
 #endif
 
   CallbackManager<void(const std::string &)> on_connect_;

--- a/components/ancs/ancs_component.h
+++ b/components/ancs/ancs_component.h
@@ -26,7 +26,9 @@ class AncsComponent : public Component {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
-  void set_device_name(const std::string &n) { device_name_ = n; }
+  void set_base_name(const std::string &n) { base_name_ = n; }
+  void set_name_configured(bool configured) { name_configured_ = configured; }
+  void set_name_suffix(const std::string &suffix);
   void set_auto_fetch(bool b) { auto_fetch_ = b; }
   void set_manufacturer(const std::string &m) { manufacturer_ = m; }
   void set_model(const std::string &m) { model_ = m; }
@@ -72,7 +74,13 @@ class AncsComponent : public Component {
 
  protected:
   AncsBle ble_;
-  std::string device_name_{"ESPHome-ANCS"};
+  std::string base_name_;
+  bool name_configured_{false};
+  std::string name_suffix_;
+  bool ble_initialized_{false};
+
+  // Resolve the effective advertised name from base/node name + suffix.
+  std::string resolve_name() const;
   std::string manufacturer_{"ESPHome"};
   std::string model_{"ANCS Node"};
   bool auto_fetch_{true};

--- a/components/ancs/ancs_name_resolver.cpp
+++ b/components/ancs/ancs_name_resolver.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Brian Towles
+
+#include "ancs_name_resolver.h"
+#include <algorithm>
+#include <cctype>
+
+namespace esphome {
+namespace ancs {
+
+namespace {
+
+std::string trim(const std::string &s) {
+  size_t start = 0;
+  size_t end = s.size();
+  while (start < end && std::isspace(static_cast<unsigned char>(s[start])))
+    start++;
+  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1])))
+    end--;
+  return s.substr(start, end - start);
+}
+
+std::string to_lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+
+// True if `name` ends with "-<mac6>" (case-insensitive).
+bool ends_with_mac_suffix(const std::string &name, const std::string &mac6) {
+  if (mac6.empty())
+    return false;
+  const std::string tail = "-" + mac6;
+  if (name.size() < tail.size())
+    return false;
+  return to_lower(name.substr(name.size() - tail.size())) == to_lower(tail);
+}
+
+std::string clamp(const std::string &s, size_t max_len) {
+  return s.size() > max_len ? s.substr(0, max_len) : s;
+}
+
+}  // namespace
+
+std::string resolve_ble_name(const std::string &configured_name, bool name_configured, const std::string &node_name,
+                             const std::string &mac6, const std::string &suffix) {
+  const std::string s = trim(suffix);
+
+  if (s.empty()) {
+    // No suffix: use the configured ancs name, or the node name as-is (the node
+    // name keeps any auto MAC suffix for uniqueness).
+    return clamp(name_configured ? configured_name : node_name, MAX_ADV_NAME_LEN);
+  }
+
+  // Suffix present: build "<base>-<suffix>".
+  std::string base;
+  if (name_configured) {
+    base = configured_name;
+  } else {
+    base = node_name;
+    if (ends_with_mac_suffix(base, mac6))
+      base = base.substr(0, base.size() - (mac6.size() + 1));
+  }
+
+  // Preserve the suffix; trim the base to fit the 29-char cap.
+  if (s.size() >= MAX_ADV_NAME_LEN)
+    return s.substr(0, MAX_ADV_NAME_LEN);
+
+  const size_t base_budget = MAX_ADV_NAME_LEN - 1 - s.size();  // room for '-' + suffix
+  if (base.size() > base_budget)
+    base = base.substr(0, base_budget);
+  if (base.empty())
+    return s;  // no room for base/dash — return the suffix alone
+  return base + "-" + s;
+}
+
+}  // namespace ancs
+}  // namespace esphome

--- a/components/ancs/ancs_name_resolver.h
+++ b/components/ancs/ancs_name_resolver.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Brian Towles
+
+#pragma once
+#include <cstddef>
+#include <string>
+
+namespace esphome {
+namespace ancs {
+
+// Maximum advertised / GAP device-name length (BLE adv-name cap).
+static constexpr size_t MAX_ADV_NAME_LEN = 29;
+
+// Pure resolution of the BLE advertised name. No ESPHome-core dependencies so it
+// can be unit-tested host-side.
+//
+//   configured_name  the `ancs: name:` value (only used when name_configured)
+//   name_configured  true if the user set `ancs: name:`
+//   node_name        App.get_name() at runtime (may be "node" or "node-<mac6>")
+//   mac6             lowercase last-6-hex of the device MAC (for suffix detection)
+//   suffix           the raw name_suffix value (may be empty / whitespace)
+//
+// Returns a name clamped to MAX_ADV_NAME_LEN. When a suffix is present it is the
+// human-meaningful part: it is preserved and the base/prefix is trimmed to fit.
+std::string resolve_ble_name(const std::string &configured_name, bool name_configured, const std::string &node_name,
+                             const std::string &mac6, const std::string &suffix);
+
+}  // namespace ancs
+}  // namespace esphome

--- a/components/ancs/ancs_name_suffix_text.cpp
+++ b/components/ancs/ancs_name_suffix_text.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Brian Towles
 
 #include "ancs_name_suffix_text.h"
+#ifdef USE_TEXT
 #include "ancs_name_resolver.h"
 #include "esphome/core/log.h"
 #include <cstring>
@@ -49,3 +50,5 @@ void AncsNameSuffixText::dump_config() {
 
 }  // namespace ancs
 }  // namespace esphome
+
+#endif  // USE_TEXT

--- a/components/ancs/ancs_name_suffix_text.cpp
+++ b/components/ancs/ancs_name_suffix_text.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Brian Towles
+
+#include "ancs_name_suffix_text.h"
+#include "esphome/core/log.h"
+#include <cstring>
+
+namespace esphome {
+namespace ancs {
+
+static const char *const TAG = "ancs.text";
+
+// Stored-suffix cap. The final advertised name is capped at 29 chars, so a
+// suffix beyond this is never useful; keep the NVS record small and fixed-size.
+static const size_t SUFFIX_STORE_MAX = 31;
+
+void AncsNameSuffixText::setup() {
+  std::string restored;
+  if (this->restore_value_) {
+    this->pref_ = global_preferences->make_preference<char[SUFFIX_STORE_MAX + 1]>(this->get_object_id_hash());
+    char buf[SUFFIX_STORE_MAX + 1] = {};
+    if (this->pref_.load(&buf)) {
+      buf[SUFFIX_STORE_MAX] = '\0';
+      restored = buf;
+    }
+  }
+  this->publish_state(restored);
+  if (this->parent_ != nullptr)
+    this->parent_->set_name_suffix(restored);
+}
+
+void AncsNameSuffixText::control(const std::string &value) {
+  this->publish_state(value);
+  if (this->restore_value_) {
+    char buf[SUFFIX_STORE_MAX + 1] = {};
+    std::strncpy(buf, value.c_str(), SUFFIX_STORE_MAX);
+    this->pref_.save(&buf);
+  }
+  if (this->parent_ != nullptr)
+    this->parent_->set_name_suffix(value);
+}
+
+void AncsNameSuffixText::dump_config() {
+  LOG_TEXT("", "ANCS Name Suffix", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace ancs
+}  // namespace esphome

--- a/components/ancs/ancs_name_suffix_text.cpp
+++ b/components/ancs/ancs_name_suffix_text.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Brian Towles
 
 #include "ancs_name_suffix_text.h"
+#include "ancs_name_resolver.h"
 #include "esphome/core/log.h"
 #include <cstring>
 
@@ -10,9 +11,10 @@ namespace ancs {
 
 static const char *const TAG = "ancs.text";
 
-// Stored-suffix cap. The final advertised name is capped at 29 chars, so a
-// suffix beyond this is never useful; keep the NVS record small and fixed-size.
-static const size_t SUFFIX_STORE_MAX = 31;
+// Stored-suffix cap. Matches the advertised-name cap (MAX_ADV_NAME_LEN) so a
+// suffix beyond this is never useful; keep the NVS record small and fixed-size,
+// and keep a single source of truth for the limit.
+static const size_t SUFFIX_STORE_MAX = MAX_ADV_NAME_LEN;
 
 void AncsNameSuffixText::setup() {
   std::string restored;

--- a/components/ancs/ancs_name_suffix_text.h
+++ b/components/ancs/ancs_name_suffix_text.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Brian Towles
+
+#pragma once
+#include "esphome/components/text/text.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+#include "ancs_component.h"
+#include <string>
+
+namespace esphome {
+namespace ancs {
+
+// A friendly name suffix, settable from any ESPHome frontend (HA / MQTT /
+// web_server) and persisted to NVS. On change it pushes the value into the
+// AncsComponent, which re-resolves the advertised name and re-advertises.
+class AncsNameSuffixText : public text::Text, public Component {
+ public:
+  void set_parent(AncsComponent *parent) { parent_ = parent; }
+  void set_restore_value(bool restore) { restore_value_ = restore; }
+
+  void setup() override;
+  void dump_config() override;
+  // Run before the ANCS component (AFTER_WIFI) so the restored suffix is pushed
+  // into the component before BLE init builds the first advertisement.
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(const std::string &value) override;
+
+  AncsComponent *parent_{nullptr};
+  bool restore_value_{true};
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace ancs
+}  // namespace esphome

--- a/components/ancs/ancs_name_suffix_text.h
+++ b/components/ancs/ancs_name_suffix_text.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 Brian Towles
 
 #pragma once
+#include "esphome/core/defines.h"
+#ifdef USE_TEXT
 #include "esphome/components/text/text.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
@@ -35,3 +37,5 @@ class AncsNameSuffixText : public text::Text, public Component {
 
 }  // namespace ancs
 }  // namespace esphome
+
+#endif  // USE_TEXT

--- a/components/ancs/text.py
+++ b/components/ancs/text.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Brian Towles
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text
+from esphome.const import CONF_RESTORE_VALUE
+
+from . import AncsComponent, ancs_ns
+
+CONF_ANCS_ID = "ancs_id"
+
+AncsNameSuffixText = ancs_ns.class_("AncsNameSuffixText", text.Text, cg.Component)
+
+CONFIG_SCHEMA = (
+    text.text_schema(AncsNameSuffixText, mode="TEXT")
+    .extend(
+        {
+            cv.GenerateID(CONF_ANCS_ID): cv.use_id(AncsComponent),
+            cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ANCS_ID])
+    var = await text.new_text(config, min_length=0, max_length=29, pattern=None)
+    await cg.register_component(var, config)
+    cg.add(var.set_parent(parent))
+    cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))

--- a/components/ancs/text_sensor.py
+++ b/components/ancs/text_sensor.py
@@ -4,6 +4,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import AncsComponent
 
@@ -13,6 +14,7 @@ CONF_LAST_TITLE = "last_title"
 CONF_LAST_MESSAGE = "last_message"
 CONF_LAST_APP_ID = "last_app_id"
 CONF_LAST_CALLER = "last_caller"
+CONF_ADVERTISED_NAME = "advertised_name"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -22,6 +24,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_LAST_MESSAGE): text_sensor.text_sensor_schema(),
         cv.Optional(CONF_LAST_APP_ID): text_sensor.text_sensor_schema(),
         cv.Optional(CONF_LAST_CALLER): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_ADVERTISED_NAME): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            icon="mdi:bluetooth",
+        ),
     }
 )
 
@@ -31,6 +37,7 @@ _SETTERS = {
     CONF_LAST_MESSAGE: "set_last_message_text_sensor",
     CONF_LAST_APP_ID: "set_last_app_id_text_sensor",
     CONF_LAST_CALLER: "set_last_caller_text_sensor",
+    CONF_ADVERTISED_NAME: "set_advertised_name_text_sensor",
 }
 
 

--- a/examples/ha-events.yaml
+++ b/examples/ha-events.yaml
@@ -77,6 +77,7 @@
 
 esphome:
   name: ancs-ha-bridge
+  name_add_mac_suffix: true
 
 esp32:
   board: esp32dev

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,13 +1,13 @@
 CXX ?= clang++
 CXXFLAGS := -std=gnu++17 -Wall -Wextra -Werror -I. -I../components/ancs
-SRC := test_ancs_protocol.cpp ../components/ancs/ancs_protocol.cpp
+SRC := test_ancs_protocol.cpp test_ancs_name.cpp ../components/ancs/ancs_protocol.cpp ../components/ancs/ancs_name_resolver.cpp
 BIN := build/test_ancs
 
 .PHONY: test clean
 test: $(BIN)
 	./$(BIN)
 
-$(BIN): $(SRC) doctest.h ../components/ancs/ancs_protocol.h
+$(BIN): $(SRC) doctest.h ../components/ancs/ancs_protocol.h ../components/ancs/ancs_name_resolver.h
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) -o $(BIN) $(SRC)
 

--- a/test/test_ancs_name.cpp
+++ b/test/test_ancs_name.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Brian Towles
+
+#include "doctest.h"
+#include "ancs_name_resolver.h"
+
+using esphome::ancs::resolve_ble_name;
+
+TEST_CASE("no suffix, configured ancs name -> ancs name") {
+  CHECK(resolve_ble_name("MyDevice", true, "node-a1b2c3", "a1b2c3", "") == "MyDevice");
+}
+
+TEST_CASE("no suffix, no ancs name -> node name kept as-is (mac retained)") {
+  CHECK(resolve_ble_name("", false, "ancservice-a1b2c3", "a1b2c3", "") == "ancservice-a1b2c3");
+}
+
+TEST_CASE("no suffix, no ancs name, no mac suffix -> node name") {
+  CHECK(resolve_ble_name("", false, "ancservice", "a1b2c3", "") == "ancservice");
+}
+
+TEST_CASE("suffix + configured ancs name -> appended") {
+  CHECK(resolve_ble_name("MyDevice", true, "node-a1b2c3", "a1b2c3", "Kitchen") == "MyDevice-Kitchen");
+}
+
+TEST_CASE("suffix + node name with mac -> mac segment replaced") {
+  CHECK(resolve_ble_name("", false, "ancservice-a1b2c3", "a1b2c3", "Kitchen") == "ancservice-Kitchen");
+}
+
+TEST_CASE("suffix + node name without mac -> appended") {
+  CHECK(resolve_ble_name("", false, "ancservice", "a1b2c3", "Kitchen") == "ancservice-Kitchen");
+}
+
+TEST_CASE("mac suffix match is case-insensitive") {
+  CHECK(resolve_ble_name("", false, "ancservice-A1B2C3", "a1b2c3", "Kitchen") == "ancservice-Kitchen");
+}
+
+TEST_CASE("whitespace-only suffix is treated as cleared") {
+  CHECK(resolve_ble_name("", false, "ancservice-a1b2c3", "a1b2c3", "   ") == "ancservice-a1b2c3");
+}
+
+TEST_CASE("suffix is trimmed") {
+  CHECK(resolve_ble_name("", false, "ancservice", "a1b2c3", "  Kitchen  ") == "ancservice-Kitchen");
+}
+
+TEST_CASE("result clamped to 29, base trimmed to keep suffix") {
+  std::string r = resolve_ble_name("verylongprefixname", true, "n", "a1b2c3", "LivingRoomDownstairs");
+  CHECK(r.size() == 29);
+  CHECK(r.substr(r.size() - 20) == "LivingRoomDownstairs");
+  CHECK(r == "verylong-LivingRoomDownstairs");
+}
+
+TEST_CASE("no-suffix name longer than 29 is clamped") {
+  std::string r = resolve_ble_name("", false, "this-node-name-is-way-too-long-for-ble", "a1b2c3", "");
+  CHECK(r.size() == 29);
+  CHECK(r == "this-node-name-is-way-too-lon");
+}

--- a/tests/test-ancs.yaml
+++ b/tests/test-ancs.yaml
@@ -79,6 +79,8 @@ text_sensor:
       name: "Last Message"
     last_caller:
       name: "Last Caller"
+    advertised_name:
+      name: "Advertised Name"
 
 interval:
   - interval: 3600s

--- a/tests/test-ancs.yaml
+++ b/tests/test-ancs.yaml
@@ -1,5 +1,6 @@
 esphome:
   name: ancs-test
+  name_add_mac_suffix: true
 
 esp32:
   board: esp32dev
@@ -15,7 +16,6 @@ external_components:
 
 ancs:
   id: my_ancs
-  name: "ESPHome-ANCS"
   auto_fetch_attributes: true
   fetch_attributes: [app_id, title, message]
   max_connections: 3
@@ -89,3 +89,8 @@ interval:
       - ancs.request_attributes:
           id: my_ancs
           uid: 0
+
+text:
+  - platform: ancs
+    ancs_id: my_ancs
+    name: "Device Name Suffix"

--- a/tests/test-ancs.yaml
+++ b/tests/test-ancs.yaml
@@ -94,3 +94,4 @@ text:
   - platform: ancs
     ancs_id: my_ancs
     name: "Device Name Suffix"
+    entity_category: config


### PR DESCRIPTION
Closes #20.

## Direction (changed from the original proposal in #20)

The issue originally proposed a two-tier design with an **ANCS-specific `name_add_mac_suffix`** option mirroring ESPHome core, plus a runtime override that fully *replaces* the name. During design we changed direction:

- **Tier 1 is delegated to ESPHome itself.** The advertised name now **defaults to the ESPHome node name** (`App.get_name()`). Per-device uniqueness comes from the existing `esphome: name_add_mac_suffix: true` (which already yields `node-a1b2c3` at runtime) — so there is **no ANCS-specific MAC-suffix option**. Less code, no double-suffix, idiomatic.
- **Tier 2 is a friendly *suffix*, not a full override.** A new `text` entity (`name_suffix`) sets a human label that **replaces the MAC segment** when present (`ancservice-a1b2c3` → `ancservice-Kitchen`) or is **appended** when not (`ancservice` → `ancservice-Kitchen`). With an explicit `ancs: name:` it is appended to that base.

Resolution precedence: a non-empty `name_suffix` wins; otherwise the explicit `ancs: name:`; otherwise the node name (MAC suffix kept). Final name is clamped to the 29-char BLE cap (the suffix is preserved, the base trimmed).

## What's included

- Pure, host-tested `resolve_ble_name()` (`components/ancs/ancs_name_resolver.*`) implementing the precedence + MAC replace/strip + clamp rule (11 doctest cases).
- `AncsBle::set_advertised_name()` — runtime GAP rename that reuses the existing deferred-advertisement rebuild; existing iOS bonds are preserved (bonds key on IRK/address, not the name).
- Component wiring: `resolve_name()` (node name + runtime MAC + suffix) and `set_name_suffix()` with a live re-advertise.
- New ESPHome `text` platform `name_suffix` (`AncsNameSuffixText`) — NVS-persisted, applied live (no reboot), editable from Home Assistant, MQTT, and the local **web_server** UI.
- `ancs: name:` is now **optional** (was defaulting to `ESPHome-ANCS`).
- README docs (incl. an upgrade note about the changed default) and an updated compile fixture.

## ⚠️ Behavior change

Previously, omitting `name:` advertised the static `ESPHome-ANCS`. It now defaults to the ESPHome node name. Users relying on the old default can set `name: "ESPHome-ANCS"` explicitly on `ancs:`. (Documented in the README upgrade note.)

## Known follow-ups (non-blocking)

- While all BLE connection slots are in use the device isn't advertising, so the *broadcast* name refreshes on the next advertising cycle (after a disconnect); the GAP characteristic updates immediately. (Documented.)
- `ble_svc_gap_device_name_set()` is called at runtime from the main task while the NimBLE host task runs — low-risk small buffer write; worth a confirmation pass against NimBLE internals if we want belt-and-suspenders.

## Test plan

- [x] Host unit tests: `make -C test test` → 27/27 pass
- [x] `esphome config tests/test-ancs.yaml` → valid
- [x] `esphome compile tests/test-ancs.yaml` → clean link (text platform + component)
- [x] On-device: two units show distinct `node-a1b2c3` names in nRF Connect
- [x] On-device: set `name_suffix` from HA and from the web_server page → re-advertises live, survives reboot
- [x] On-device: rename while an iPhone is bonded → bond preserved, no re-pairing